### PR TITLE
Fix GSNSignatureBouncer signature bug

### DIFF
--- a/contracts/GSN/bouncers/GSNBouncerSignature.sol
+++ b/contracts/GSN/bouncers/GSNBouncerSignature.sol
@@ -16,6 +16,7 @@ contract GSNBouncerSignature is Initializable, GSNBouncerBase {
     }
 
     function initialize(address trustedSigner) public initializer {
+        require(trustedSigner != address(0), "Trusted Signer can not be a ZeroAddress");
         _setTrustedSigner(trustedSigner);
     }
 
@@ -46,7 +47,11 @@ contract GSNBouncerSignature is Initializable, GSNBouncerBase {
             address(this) // Prevents replays in multiple recipients
         );
         if (keccak256(blob).toEthSignedMessageHash().recover(approvalData) == _getTrustedSigner()) {
+            if (_getTrustedSigner() != address(0)){
             return _approveRelayedCall();
+            } else {
+            return _rejectRelayedCall(uint256(GSNBouncerSignatureErrorCodes.INVALID_SIGNER));
+            }
         } else {
             return _rejectRelayedCall(uint256(GSNBouncerSignatureErrorCodes.INVALID_SIGNER));
         }


### PR DESCRIPTION
The GSNSignatureBouncer currently accepts a zero address as a trusted signer. Even more unexpected however, is that the failure to initialize the GSNSignatureBouncer will allow the  bouncer to accept no signature at all.

When uninitialized, _getTrustedSigner() will resolve a zero address for unset values. For people who deploy and fail to initialize their bouncer, their GSN contract will simply "magically" work for anyone who does not provide a signature, but they won't know that even though their valid provided signatures will always fail.

I've added a catch so that the trustedSigner can not be set to 0x0, and a check so that it will not relay transactions when no `trustedSigner` has been set at all.

<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

As noted above, the GSNSignatureBouncer allows for Zero addresses for `trustedSigners` as well unexpectedly approving GSN transactions when no signature is provided at all. 

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
