### PR TITLE
Move new variable to the end of ERC721Metadata contract storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,16 @@ jobs:
       - run:
           name: Linter
           command: npm run lint
+  
   test:
     <<: *defaults
     steps:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Recompile contracts
+          command: npm run compile
       - run:
           name: Unit tests
           command: npm run test

--- a/contracts/examples/SimpleToken.sol
+++ b/contracts/examples/SimpleToken.sol
@@ -12,7 +12,7 @@ import "../token/ERC20/ERC20Detailed.sol";
  * Note they can later distribute these tokens as they wish using `transfer` and other
  * `ERC20` functions.
  */
-contract SimpleToken is Initializable, Context,  ERC20, ERC20Detailed {
+contract SimpleToken is Initializable, Context, ERC20, ERC20Detailed {
 
     /**
      * @dev Constructor that gives _msgSender() all of existing tokens.

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -40,7 +40,7 @@ contract MessageHelper {
     }
 
     function call(address _to, bytes memory _data) public returns (bool) {
-        // solhint-disable-next-line security/avoid-low-level-calls
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success,) = _to.call(_data);
         if (success)
             return true;

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -14,11 +14,11 @@ contract ERC721Metadata is Initializable, Context, ERC165, ERC721, IERC721Metada
     // Token symbol
     string private _symbol;
 
-    // Base URI
-    string private _baseURI;
-
     // Optional mapping for token URIs
     mapping(uint256 => string) private _tokenURIs;
+
+    // Base URI
+    string private _baseURI;
 
     /*
      *     bytes4(keccak256('name()')) == 0x06fdde03

--- a/contracts/token/ERC721/ERC721Metadata.sol
+++ b/contracts/token/ERC721/ERC721Metadata.sol
@@ -135,5 +135,5 @@ contract ERC721Metadata is Initializable, Context, ERC165, ERC721, IERC721Metada
         }
     }
 
-    uint256[50] private ______gap;
+    uint256[49] private ______gap;
 }

--- a/scripts/gen-nav.js
+++ b/scripts/gen-nav.js
@@ -7,7 +7,7 @@ const startCase = require('lodash.startcase');
 const baseDir = process.argv[2];
 
 const files = proc.execFileSync(
-  'find', [baseDir, '-type', 'f'], { encoding: 'utf8' }
+  'find', [baseDir, '-type', 'f'], { encoding: 'utf8' },
 ).split('\n').filter(s => s !== '');
 
 console.log('.API');

--- a/scripts/release/update-changelog-release-date.js
+++ b/scripts/release/update-changelog-release-date.js
@@ -27,7 +27,7 @@ if (changelog.indexOf(`## ${version} (unreleased)`) === -1) {
 
 fs.writeFileSync('CHANGELOG.md', changelog.replace(
   `## ${version} (unreleased)`,
-  `## ${version} (${new Date().toISOString().split('T')[0]})`)
+  `## ${version} (${new Date().toISOString().split('T')[0]})`),
 );
 
 cp.execSync('git add CHANGELOG.md', { stdio: 'inherit' });

--- a/test/GSN/ERC721GSNRecipientMock.test.js
+++ b/test/GSN/ERC721GSNRecipientMock.test.js
@@ -39,9 +39,9 @@ describe('ERC721GSNRecipient (integration)', function () {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, this.token.address
-            ), signer
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, this.token.address,
+            ), signer,
+          ),
         );
 
       await testMintToken(this.token, sender, tokenId, { useGSN: true, approveFunction });

--- a/test/GSN/GSNRecipient.test.js
+++ b/test/GSN/GSNRecipient.test.js
@@ -38,13 +38,13 @@ describe('GSNRecipient', function () {
     it('cannot upgrade to the same RelayHub', async function () {
       await expectRevert(
         this.recipient.upgradeRelayHub(singletonRelayHub),
-        'GSNRecipient: new RelayHub is the current one'
+        'GSNRecipient: new RelayHub is the current one',
       );
     });
 
     it('cannot upgrade to the zero address', async function () {
       await expectRevert(
-        this.recipient.upgradeRelayHub(ZERO_ADDRESS), 'GSNRecipient: new RelayHub is the zero address'
+        this.recipient.upgradeRelayHub(ZERO_ADDRESS), 'GSNRecipient: new RelayHub is the zero address',
       );
     });
 

--- a/test/GSN/GSNRecipientSignature.test.js
+++ b/test/GSN/GSNRecipientSignature.test.js
@@ -26,9 +26,9 @@ describe('GSNRecipientSignature', function () {
     it('fails when constructor called with a zero address', async function () {
       await expectRevert(
         GSNRecipientSignatureMock.new(
-          ZERO_ADDRESS
+          ZERO_ADDRESS,
         ),
-        'GSNRecipientSignature: trusted signer is the zero address'
+        'GSNRecipientSignature: trusted signer is the zero address',
       );
     });
   });
@@ -49,9 +49,9 @@ describe('GSNRecipientSignature', function () {
             web3.utils.soliditySha3(
               // the nonce is not signed
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas)
-            ), signer
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas),
+            ), signer,
+          ),
         );
 
       await gsn.expectError(this.recipient.mockFunction({ value: 0, useGSN: true, approveFunction }));
@@ -63,9 +63,9 @@ describe('GSNRecipientSignature', function () {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to
-            ), signer
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to,
+            ), signer,
+          ),
         );
 
       const { tx } = await this.recipient.mockFunction({ value: 0, useGSN: true, approveFunction });
@@ -79,9 +79,9 @@ describe('GSNRecipientSignature', function () {
           await web3.eth.sign(
             web3.utils.soliditySha3(
               // eslint-disable-next-line max-len
-              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to
-            ), other
-          )
+              data.relayerAddress, data.from, data.encodedFunctionCall, toBN(data.txFee), toBN(data.gasPrice), toBN(data.gas), toBN(data.nonce), data.relayHubAddress, data.to,
+            ), other,
+          ),
         );
 
       await gsn.expectError(this.recipient.mockFunction({ value: 0, useGSN: true, approveFunction }));

--- a/test/behaviors/access/roles/PublicRole.behavior.js
+++ b/test/behaviors/access/roles/PublicRole.behavior.js
@@ -42,7 +42,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
 
     it('reverts when querying roles for the null account', async function () {
       await expectRevert(this.contract[`is${rolename}`](ZERO_ADDRESS),
-        'Roles: account is the zero address'
+        'Roles: account is the zero address',
       );
     });
 
@@ -60,7 +60,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
 
         it('reverts', async function () {
           await expectRevert(this.contract[`only${rolename}Mock`]({ from }),
-            `${rolename}Role: caller does not have the ${rolename} role`
+            `${rolename}Role: caller does not have the ${rolename} role`,
           );
         });
       });
@@ -82,13 +82,13 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
 
         it('reverts when adding role to an already assigned account', async function () {
           await expectRevert(this.contract[`add${rolename}`](authorized, { from }),
-            'Roles: account already has role'
+            'Roles: account already has role',
           );
         });
 
         it('reverts when adding role to the null account', async function () {
           await expectRevert(this.contract[`add${rolename}`](ZERO_ADDRESS, { from }),
-            'Roles: account is the zero address'
+            'Roles: account is the zero address',
           );
         });
       });
@@ -112,13 +112,13 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
 
         it('reverts when removing from an unassigned account', async function () {
           await expectRevert(this.contract[`remove${rolename}`](other, { from }),
-            'Roles: account does not have role'
+            'Roles: account does not have role',
           );
         });
 
         it('reverts when removing role from the null account', async function () {
           await expectRevert(this.contract[`remove${rolename}`](ZERO_ADDRESS, { from }),
-            'Roles: account is the zero address'
+            'Roles: account is the zero address',
           );
         });
       });
@@ -137,7 +137,7 @@ function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolen
 
       it('reverts when renouncing unassigned role', async function () {
         await expectRevert(this.contract[`renounce${rolename}`]({ from: other }),
-          'Roles: account does not have role'
+          'Roles: account does not have role',
         );
       });
     });

--- a/test/crowdsale/AllowanceCrowdsale.test.js
+++ b/test/crowdsale/AllowanceCrowdsale.test.js
@@ -82,7 +82,7 @@ describe('AllowanceCrowdsale', function () {
     it('creation reverts', async function () {
       this.token = await SimpleToken.new({ from: tokenWallet });
       await expectRevert(AllowanceCrowdsaleImpl.new(rate, wallet, this.token.address, ZERO_ADDRESS),
-        'AllowanceCrowdsale: token wallet is the zero address'
+        'AllowanceCrowdsale: token wallet is the zero address',
       );
     });
   });

--- a/test/crowdsale/CappedCrowdsale.test.js
+++ b/test/crowdsale/CappedCrowdsale.test.js
@@ -21,7 +21,7 @@ describe('CappedCrowdsale', function () {
 
   it('rejects a cap of zero', async function () {
     await expectRevert(CappedCrowdsaleImpl.new(rate, wallet, this.token.address, 0),
-      'CappedCrowdsale: cap is 0'
+      'CappedCrowdsale: cap is 0',
     );
   });
 

--- a/test/crowdsale/Crowdsale.test.js
+++ b/test/crowdsale/Crowdsale.test.js
@@ -19,7 +19,7 @@ describe('Crowdsale', function () {
   it('requires a non-null token', async function () {
     await expectRevert(
       Crowdsale.new(rate, wallet, ZERO_ADDRESS),
-      'Crowdsale: token is the zero address'
+      'Crowdsale: token is the zero address',
     );
   });
 
@@ -30,13 +30,13 @@ describe('Crowdsale', function () {
 
     it('requires a non-zero rate', async function () {
       await expectRevert(
-        Crowdsale.new(0, wallet, this.token.address), 'Crowdsale: rate is 0'
+        Crowdsale.new(0, wallet, this.token.address), 'Crowdsale: rate is 0',
       );
     });
 
     it('requires a non-null wallet', async function () {
       await expectRevert(
-        Crowdsale.new(rate, ZERO_ADDRESS, this.token.address), 'Crowdsale: wallet is the zero address'
+        Crowdsale.new(rate, ZERO_ADDRESS, this.token.address), 'Crowdsale: wallet is the zero address',
       );
     });
 
@@ -54,7 +54,7 @@ describe('Crowdsale', function () {
 
           it('reverts on zero-valued payments', async function () {
             await expectRevert(
-              this.crowdsale.send(0, { from: purchaser }), 'Crowdsale: weiAmount is 0'
+              this.crowdsale.send(0, { from: purchaser }), 'Crowdsale: weiAmount is 0',
             );
           });
         });
@@ -66,14 +66,14 @@ describe('Crowdsale', function () {
 
           it('reverts on zero-valued payments', async function () {
             await expectRevert(
-              this.crowdsale.buyTokens(investor, { value: 0, from: purchaser }), 'Crowdsale: weiAmount is 0'
+              this.crowdsale.buyTokens(investor, { value: 0, from: purchaser }), 'Crowdsale: weiAmount is 0',
             );
           });
 
           it('requires a non-null beneficiary', async function () {
             await expectRevert(
               this.crowdsale.buyTokens(ZERO_ADDRESS, { value: value, from: purchaser }),
-              'Crowdsale: beneficiary is the zero address'
+              'Crowdsale: beneficiary is the zero address',
             );
           });
         });

--- a/test/crowdsale/FinalizableCrowdsale.test.js
+++ b/test/crowdsale/FinalizableCrowdsale.test.js
@@ -22,13 +22,13 @@ describe('FinalizableCrowdsale', function () {
 
     this.token = await ERC20.new();
     this.crowdsale = await FinalizableCrowdsaleImpl.new(
-      this.openingTime, this.closingTime, rate, wallet, this.token.address
+      this.openingTime, this.closingTime, rate, wallet, this.token.address,
     );
   });
 
   it('cannot be finalized before ending', async function () {
     await expectRevert(this.crowdsale.finalize({ from: other }),
-      'FinalizableCrowdsale: not closed'
+      'FinalizableCrowdsale: not closed',
     );
   });
 
@@ -41,7 +41,7 @@ describe('FinalizableCrowdsale', function () {
     await time.increaseTo(this.afterClosingTime);
     await this.crowdsale.finalize({ from: other });
     await expectRevert(this.crowdsale.finalize({ from: other }),
-      'FinalizableCrowdsale: already finalized'
+      'FinalizableCrowdsale: already finalized',
     );
   });
 

--- a/test/crowdsale/IncreasingPriceCrowdsale.test.js
+++ b/test/crowdsale/IncreasingPriceCrowdsale.test.js
@@ -33,26 +33,26 @@ describe('IncreasingPriceCrowdsale', function () {
 
     it('reverts with a final rate larger than the initial rate', async function () {
       await expectRevert(IncreasingPriceCrowdsaleImpl.new(
-        this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate.addn(1)
+        this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate.addn(1),
       ), 'IncreasingPriceCrowdsale: initial rate is not greater than final rate');
     });
 
     it('reverts with a final rate equal to the initial rate', async function () {
       await expectRevert(IncreasingPriceCrowdsaleImpl.new(
-        this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate
+        this.startTime, this.closingTime, wallet, this.token.address, initialRate, initialRate,
       ), 'IncreasingPriceCrowdsale: initial rate is not greater than final rate');
     });
 
     it('reverts with a final rate of zero', async function () {
       await expectRevert(IncreasingPriceCrowdsaleImpl.new(
-        this.startTime, this.closingTime, wallet, this.token.address, initialRate, 0
+        this.startTime, this.closingTime, wallet, this.token.address, initialRate, 0,
       ), 'IncreasingPriceCrowdsale: final rate is 0');
     });
 
     context('with crowdsale', function () {
       beforeEach(async function () {
         this.crowdsale = await IncreasingPriceCrowdsaleImpl.new(
-          this.startTime, this.closingTime, wallet, this.token.address, initialRate, finalRate
+          this.startTime, this.closingTime, wallet, this.token.address, initialRate, finalRate,
         );
         await this.token.transfer(this.crowdsale.address, tokenSupply);
       });
@@ -64,7 +64,7 @@ describe('IncreasingPriceCrowdsale', function () {
 
       it('reverts when the base Crowdsale\'s rate function is called', async function () {
         await expectRevert(this.crowdsale.rate(),
-          'IncreasingPriceCrowdsale: rate() called'
+          'IncreasingPriceCrowdsale: rate() called',
         );
       });
 

--- a/test/crowdsale/IndividuallyCappedCrowdsale.test.js
+++ b/test/crowdsale/IndividuallyCappedCrowdsale.test.js
@@ -41,7 +41,7 @@ describe('IndividuallyCappedCrowdsale', function () {
 
     it('reverts when a non-capper sets a cap', async function () {
       await expectRevert(this.crowdsale.setCap(alice, capAlice, { from: other }),
-        'CapperRole: caller does not have the Capper role'
+        'CapperRole: caller does not have the Capper role',
       );
     });
 
@@ -61,29 +61,29 @@ describe('IndividuallyCappedCrowdsale', function () {
         it('should reject payments outside cap', async function () {
           await this.crowdsale.buyTokens(alice, { value: capAlice });
           await expectRevert(this.crowdsale.buyTokens(alice, { value: 1 }),
-            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
+            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded',
           );
         });
 
         it('should reject payments that exceed cap', async function () {
           await expectRevert(this.crowdsale.buyTokens(alice, { value: capAlice.addn(1) }),
-            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
+            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded',
           );
           await expectRevert(this.crowdsale.buyTokens(bob, { value: capBob.addn(1) }),
-            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
+            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded',
           );
         });
 
         it('should manage independent caps', async function () {
           await this.crowdsale.buyTokens(alice, { value: lessThanCapAlice });
           await expectRevert(this.crowdsale.buyTokens(bob, { value: lessThanCapAlice }),
-            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
+            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded',
           );
         });
 
         it('should default to a cap of zero', async function () {
           await expectRevert(this.crowdsale.buyTokens(charlie, { value: lessThanCapBoth }),
-            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded'
+            'IndividuallyCappedCrowdsale: beneficiary\'s cap exceeded',
           );
         });
       });

--- a/test/crowdsale/PausableCrowdsale.test.js
+++ b/test/crowdsale/PausableCrowdsale.test.js
@@ -31,10 +31,10 @@ describe('PausableCrowdsale', function () {
 
     it('purchases do not work', async function () {
       await expectRevert(this.crowdsale.sendTransaction({ from: other, value }),
-        'Pausable: paused'
+        'Pausable: paused',
       );
       await expectRevert(this.crowdsale.buyTokens(other, { from: other, value }),
-        'Pausable: paused'
+        'Pausable: paused',
       );
     });
 

--- a/test/crowdsale/PostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/PostDeliveryCrowdsale.test.js
@@ -24,7 +24,7 @@ describe('PostDeliveryCrowdsale', function () {
     this.afterClosingTime = this.closingTime.add(time.duration.seconds(1));
     this.token = await SimpleToken.new();
     this.crowdsale = await PostDeliveryCrowdsaleImpl.new(
-      this.openingTime, this.closingTime, rate, wallet, this.token.address
+      this.openingTime, this.closingTime, rate, wallet, this.token.address,
     );
     await this.token.transfer(this.crowdsale.address, tokenSupply);
   });
@@ -48,7 +48,7 @@ describe('PostDeliveryCrowdsale', function () {
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
         await expectRevert(this.crowdsale.withdrawTokens(investor),
-          'PostDeliveryCrowdsale: not closed'
+          'PostDeliveryCrowdsale: not closed',
         );
       });
 
@@ -66,7 +66,7 @@ describe('PostDeliveryCrowdsale', function () {
         it('rejects multiple withdrawals', async function () {
           await this.crowdsale.withdrawTokens(investor);
           await expectRevert(this.crowdsale.withdrawTokens(investor),
-            'PostDeliveryCrowdsale: beneficiary is not due any tokens'
+            'PostDeliveryCrowdsale: beneficiary is not due any tokens',
           );
         });
       });

--- a/test/crowdsale/RefundableCrowdsale.test.js
+++ b/test/crowdsale/RefundableCrowdsale.test.js
@@ -32,14 +32,14 @@ describe('RefundableCrowdsale', function () {
   it('rejects a goal of zero', async function () {
     await expectRevert(
       RefundableCrowdsaleImpl.new(this.openingTime, this.closingTime, rate, wallet, this.token.address, 0),
-      'RefundableCrowdsale: goal is 0'
+      'RefundableCrowdsale: goal is 0',
     );
   });
 
   context('with crowdsale', function () {
     beforeEach(async function () {
       this.crowdsale = await RefundableCrowdsaleImpl.new(
-        this.openingTime, this.closingTime, rate, wallet, this.token.address, goal
+        this.openingTime, this.closingTime, rate, wallet, this.token.address, goal,
       );
 
       await this.token.transfer(this.crowdsale.address, tokenSupply);
@@ -48,7 +48,7 @@ describe('RefundableCrowdsale', function () {
     context('before opening time', function () {
       it('denies refunds', async function () {
         await expectRevert(this.crowdsale.claimRefund(investor),
-          'RefundableCrowdsale: not finalized'
+          'RefundableCrowdsale: not finalized',
         );
       });
     });
@@ -60,7 +60,7 @@ describe('RefundableCrowdsale', function () {
 
       it('denies refunds', async function () {
         await expectRevert(this.crowdsale.claimRefund(investor),
-          'RefundableCrowdsale: not finalized'
+          'RefundableCrowdsale: not finalized',
         );
       });
 
@@ -96,7 +96,7 @@ describe('RefundableCrowdsale', function () {
 
           it('denies refunds', async function () {
             await expectRevert(this.crowdsale.claimRefund(investor),
-              'RefundableCrowdsale: goal reached'
+              'RefundableCrowdsale: goal reached',
             );
           });
 

--- a/test/crowdsale/RefundablePostDeliveryCrowdsale.test.js
+++ b/test/crowdsale/RefundablePostDeliveryCrowdsale.test.js
@@ -28,7 +28,7 @@ describe('RefundablePostDeliveryCrowdsale', function () {
       this.openingTime, this.closingTime, rate, wallet, this.token.address, goal,
       {
         gas: '0xffffff',
-      }
+      },
     );
     await this.token.transfer(this.crowdsale.address, tokenSupply);
   });
@@ -52,7 +52,7 @@ describe('RefundablePostDeliveryCrowdsale', function () {
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
         await expectRevert(this.crowdsale.withdrawTokens(investor),
-          'RefundablePostDeliveryCrowdsale: not finalized'
+          'RefundablePostDeliveryCrowdsale: not finalized',
         );
       });
 
@@ -64,7 +64,7 @@ describe('RefundablePostDeliveryCrowdsale', function () {
 
         it('rejects token withdrawals', async function () {
           await expectRevert(this.crowdsale.withdrawTokens(investor),
-            'RefundablePostDeliveryCrowdsale: goal not reached'
+            'RefundablePostDeliveryCrowdsale: goal not reached',
           );
         });
       });
@@ -84,7 +84,7 @@ describe('RefundablePostDeliveryCrowdsale', function () {
 
       it('does not allow beneficiaries to withdraw tokens before crowdsale ends', async function () {
         await expectRevert(this.crowdsale.withdrawTokens(investor),
-          'RefundablePostDeliveryCrowdsale: not finalized'
+          'RefundablePostDeliveryCrowdsale: not finalized',
         );
       });
 
@@ -103,7 +103,7 @@ describe('RefundablePostDeliveryCrowdsale', function () {
         it('rejects multiple withdrawals', async function () {
           await this.crowdsale.withdrawTokens(investor);
           await expectRevert(this.crowdsale.withdrawTokens(investor),
-            'PostDeliveryCrowdsale: beneficiary is not due any tokens'
+            'PostDeliveryCrowdsale: beneficiary is not due any tokens',
           );
         });
       });

--- a/test/crowdsale/TimedCrowdsale.test.js
+++ b/test/crowdsale/TimedCrowdsale.test.js
@@ -28,26 +28,26 @@ describe('TimedCrowdsale', function () {
 
   it('reverts if the opening time is in the past', async function () {
     await expectRevert(TimedCrowdsaleImpl.new(
-      (await time.latest()).sub(time.duration.days(1)), this.closingTime, rate, wallet, this.token.address
+      (await time.latest()).sub(time.duration.days(1)), this.closingTime, rate, wallet, this.token.address,
     ), 'TimedCrowdsale: opening time is before current time');
   });
 
   it('reverts if the closing time is before the opening time', async function () {
     await expectRevert(TimedCrowdsaleImpl.new(
-      this.openingTime, this.openingTime.sub(time.duration.seconds(1)), rate, wallet, this.token.address
+      this.openingTime, this.openingTime.sub(time.duration.seconds(1)), rate, wallet, this.token.address,
     ), 'TimedCrowdsale: opening time is not before closing time');
   });
 
   it('reverts if the closing time equals the opening time', async function () {
     await expectRevert(TimedCrowdsaleImpl.new(
-      this.openingTime, this.openingTime, rate, wallet, this.token.address
+      this.openingTime, this.openingTime, rate, wallet, this.token.address,
     ), 'TimedCrowdsale: opening time is not before closing time');
   });
 
   context('with crowdsale', function () {
     beforeEach(async function () {
       this.crowdsale = await TimedCrowdsaleImpl.new(
-        this.openingTime, this.closingTime, rate, wallet, this.token.address
+        this.openingTime, this.closingTime, rate, wallet, this.token.address,
       );
       await this.token.transfer(this.crowdsale.address, tokenSupply);
     });
@@ -64,7 +64,7 @@ describe('TimedCrowdsale', function () {
         expect(await this.crowdsale.isOpen()).to.equal(false);
         await expectRevert(this.crowdsale.send(value), 'TimedCrowdsale: not open');
         await expectRevert(this.crowdsale.buyTokens(investor, { from: purchaser, value: value }),
-          'TimedCrowdsale: not open'
+          'TimedCrowdsale: not open',
         );
       });
 
@@ -79,7 +79,7 @@ describe('TimedCrowdsale', function () {
         await time.increaseTo(this.afterClosingTime);
         await expectRevert(this.crowdsale.send(value), 'TimedCrowdsale: not open');
         await expectRevert(this.crowdsale.buyTokens(investor, { value: value, from: purchaser }),
-          'TimedCrowdsale: not open'
+          'TimedCrowdsale: not open',
         );
       });
     });
@@ -88,13 +88,13 @@ describe('TimedCrowdsale', function () {
       it('should not reduce duration', async function () {
         // Same date
         await expectRevert(this.crowdsale.extendTime(this.closingTime),
-          'TimedCrowdsale: new closing time is before current closing time'
+          'TimedCrowdsale: new closing time is before current closing time',
         );
 
         // Prescending date
         const newClosingTime = this.closingTime.sub(time.duration.seconds(1));
         await expectRevert(this.crowdsale.extendTime(newClosingTime),
-          'TimedCrowdsale: new closing time is before current closing time'
+          'TimedCrowdsale: new closing time is before current closing time',
         );
       });
 
@@ -141,7 +141,7 @@ describe('TimedCrowdsale', function () {
         it('it reverts', async function () {
           const newClosingTime = await time.latest();
           await expectRevert(this.crowdsale.extendTime(newClosingTime),
-            'TimedCrowdsale: already closed'
+            'TimedCrowdsale: already closed',
           );
         });
       });

--- a/test/crowdsale/WhitelistCrowdsale.test.js
+++ b/test/crowdsale/WhitelistCrowdsale.test.js
@@ -25,10 +25,10 @@ describe('WhitelistCrowdsale', function () {
 
   async function purchaseExpectRevert (crowdsale, beneficiary, value) {
     await expectRevert(crowdsale.buyTokens(beneficiary, { from: beneficiary, value }),
-      'WhitelistCrowdsale: beneficiary doesn\'t have the Whitelisted role'
+      'WhitelistCrowdsale: beneficiary doesn\'t have the Whitelisted role',
     );
     await expectRevert(crowdsale.sendTransaction({ from: beneficiary, value }),
-      'WhitelistCrowdsale: beneficiary doesn\'t have the Whitelisted role'
+      'WhitelistCrowdsale: beneficiary doesn\'t have the Whitelisted role',
     );
   }
 

--- a/test/cryptography/ECDSA.test.js
+++ b/test/cryptography/ECDSA.test.js
@@ -115,7 +115,7 @@ describe('ECDSA', function () {
           // Recover the signer address from the generated message and signature.
           expect(await this.ecdsa.recover(
             toEthSignedMessageHash(TEST_MESSAGE),
-            signature
+            signature,
           )).to.equal(other);
         });
       });
@@ -138,7 +138,7 @@ describe('ECDSA', function () {
         const signature = await web3.eth.sign(TEST_MESSAGE, other);
         await expectRevert(
           this.ecdsa.recover(TEST_MESSAGE.substring(2), signature),
-          'Failure message'
+          'Failure message',
         );
       });
     });

--- a/test/drafts/ERC20Migrator.test.js
+++ b/test/drafts/ERC20Migrator.test.js
@@ -16,7 +16,7 @@ describe('ERC20Migrator', function () {
 
   it('reverts with a null legacy token address', async function () {
     await expectRevert(ERC20Migrator.new(ZERO_ADDRESS),
-      'ERC20Migrator: legacy token is the zero address'
+      'ERC20Migrator: legacy token is the zero address',
     );
   });
 
@@ -34,13 +34,13 @@ describe('ERC20Migrator', function () {
     describe('beginMigration', function () {
       it('reverts with a null new token address', async function () {
         await expectRevert(this.migrator.beginMigration(ZERO_ADDRESS),
-          'ERC20Migrator: new token is the zero address'
+          'ERC20Migrator: new token is the zero address',
         );
       });
 
       it('reverts if not a minter of the token', async function () {
         await expectRevert(this.migrator.beginMigration(this.newToken.address),
-          'ERC20Migrator: not a minter for new token'
+          'ERC20Migrator: not a minter for new token',
         );
       });
 
@@ -53,7 +53,7 @@ describe('ERC20Migrator', function () {
         await this.newToken.addMinter(this.migrator.address);
         await this.migrator.beginMigration(this.newToken.address);
         await expectRevert(this.migrator.beginMigration(this.newToken.address),
-          'ERC20Migrator: migration already started'
+          'ERC20Migrator: migration already started',
         );
       });
     });
@@ -73,7 +73,7 @@ describe('ERC20Migrator', function () {
 
           it('reverts', async function () {
             await expectRevert(this.migrator.migrateAll(owner),
-              'ERC20Migrator: migration not started'
+              'ERC20Migrator: migration not started',
             );
           });
         });
@@ -89,7 +89,7 @@ describe('ERC20Migrator', function () {
 
           it('reverts', async function () {
             await expectRevert(this.migrator.migrate(owner, amount),
-              'ERC20Migrator: migration not started'
+              'ERC20Migrator: migration not started',
             );
           });
         });
@@ -193,7 +193,7 @@ describe('ERC20Migrator', function () {
 
           it('reverts', async function () {
             await expectRevert(this.migrator.migrate(owner, amount),
-              'SafeERC20: low-level call failed'
+              'SafeERC20: low-level call failed',
             );
           });
         });

--- a/test/drafts/ERC20Snapshot.test.js
+++ b/test/drafts/ERC20Snapshot.test.js
@@ -73,7 +73,7 @@ describe('ERC20Snapshot', function () {
             expect(await this.token.totalSupplyAt(this.initialSnapshotId)).to.be.bignumber.equal(initialSupply);
 
             expect(await this.token.totalSupplyAt(this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.totalSupply()
+              await this.token.totalSupply(),
             );
           });
         });
@@ -157,13 +157,13 @@ describe('ERC20Snapshot', function () {
             expect(await this.token.balanceOfAt(other, this.initialSnapshotId)).to.be.bignumber.equal('0');
 
             expect(await this.token.balanceOfAt(initialHolder, this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.balanceOf(initialHolder)
+              await this.token.balanceOf(initialHolder),
             );
             expect(await this.token.balanceOfAt(recipient, this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.balanceOf(recipient)
+              await this.token.balanceOf(recipient),
             );
             expect(await this.token.balanceOfAt(other, this.secondSnapshotId)).to.be.bignumber.equal(
-              await this.token.balanceOf(other)
+              await this.token.balanceOf(other),
             );
           });
         });
@@ -186,13 +186,13 @@ describe('ERC20Snapshot', function () {
 
             for (const id of this.secondSnapshotIds) {
               expect(await this.token.balanceOfAt(initialHolder, id)).to.be.bignumber.equal(
-                await this.token.balanceOf(initialHolder)
+                await this.token.balanceOf(initialHolder),
               );
               expect(await this.token.balanceOfAt(recipient, id)).to.be.bignumber.equal(
-                await this.token.balanceOf(recipient)
+                await this.token.balanceOf(recipient),
               );
               expect(await this.token.balanceOfAt(other, id)).to.be.bignumber.equal(
-                await this.token.balanceOf(other)
+                await this.token.balanceOf(other),
               );
             }
           });

--- a/test/drafts/TokenVesting.test.js
+++ b/test/drafts/TokenVesting.test.js
@@ -28,21 +28,21 @@ describe('TokenVesting', function () {
 
     await expectRevert(
       TokenVesting.new(beneficiary, this.start, cliffDuration, duration, true, { from: owner }),
-      'TokenVesting: cliff is longer than duration'
+      'TokenVesting: cliff is longer than duration',
     );
   });
 
   it('reverts with a null beneficiary', async function () {
     await expectRevert(
       TokenVesting.new(ZERO_ADDRESS, this.start, this.cliffDuration, this.duration, true, { from: owner }),
-      'TokenVesting: beneficiary is the zero address'
+      'TokenVesting: beneficiary is the zero address',
     );
   });
 
   it('reverts with a null duration', async function () {
     // cliffDuration should also be 0, since the duration must be larger than the cliff
     await expectRevert(
-      TokenVesting.new(beneficiary, this.start, 0, 0, true, { from: owner }), 'TokenVesting: duration is 0'
+      TokenVesting.new(beneficiary, this.start, 0, 0, true, { from: owner }), 'TokenVesting: duration is 0',
     );
   });
 
@@ -52,7 +52,7 @@ describe('TokenVesting', function () {
     this.start = now.sub(this.duration).sub(time.duration.minutes(1));
     await expectRevert(
       TokenVesting.new(beneficiary, this.start, this.cliffDuration, this.duration, true, { from: owner }),
-      'TokenVesting: final time is before current time'
+      'TokenVesting: final time is before current time',
     );
   });
 
@@ -75,7 +75,7 @@ describe('TokenVesting', function () {
 
     it('cannot be released before cliff', async function () {
       await expectRevert(this.vesting.release(this.token.address),
-        'TokenVesting: no tokens are due'
+        'TokenVesting: no tokens are due',
       );
     });
 
@@ -129,11 +129,11 @@ describe('TokenVesting', function () {
 
     it('should fail to be revoked by owner if revocable not set', async function () {
       const vesting = await TokenVesting.new(
-        beneficiary, this.start, this.cliffDuration, this.duration, false, { from: owner }
+        beneficiary, this.start, this.cliffDuration, this.duration, false, { from: owner },
       );
 
       await expectRevert(vesting.revoke(this.token.address, { from: owner }),
-        'TokenVesting: cannot revoke'
+        'TokenVesting: cannot revoke',
       );
     });
 
@@ -162,7 +162,7 @@ describe('TokenVesting', function () {
     it('should fail to be revoked a second time', async function () {
       await this.vesting.revoke(this.token.address, { from: owner });
       await expectRevert(this.vesting.revoke(this.token.address, { from: owner }),
-        'TokenVesting: token already revoked'
+        'TokenVesting: token already revoked',
       );
     });
 

--- a/test/examples/SampleCrowdsale.test.js
+++ b/test/examples/SampleCrowdsale.test.js
@@ -27,7 +27,7 @@ describe('SampleCrowdsale', function () {
     this.token = await SampleCrowdsaleToken.new({ from: deployer });
     this.crowdsale = await SampleCrowdsale.new(
       this.openingTime, this.closingTime, RATE, wallet, CAP, this.token.address, GOAL,
-      { from: owner }
+      { from: owner },
     );
 
     await this.token.addMinter(this.crowdsale.address, { from: deployer });
@@ -46,7 +46,7 @@ describe('SampleCrowdsale', function () {
   it('should not accept payments before start', async function () {
     await expectRevert(this.crowdsale.send(ether('1')), 'TimedCrowdsale: not open');
     await expectRevert(this.crowdsale.buyTokens(investor, { from: investor, value: ether('1') }),
-      'TimedCrowdsale: not open'
+      'TimedCrowdsale: not open',
     );
   });
 
@@ -65,7 +65,7 @@ describe('SampleCrowdsale', function () {
     await time.increaseTo(this.afterClosingTime);
     await expectRevert(this.crowdsale.send(ether('1')), 'TimedCrowdsale: not open');
     await expectRevert(this.crowdsale.buyTokens(investor, { value: ether('1'), from: investor }),
-      'TimedCrowdsale: not open'
+      'TimedCrowdsale: not open',
     );
   });
 
@@ -104,7 +104,7 @@ describe('SampleCrowdsale', function () {
 
     it('creation reverts', async function () {
       await expectRevert(SampleCrowdsale.new(
-        this.openingTime, this.closingTime, RATE, wallet, CAP, this.token.address, HIGH_GOAL
+        this.openingTime, this.closingTime, RATE, wallet, CAP, this.token.address, HIGH_GOAL,
       ), 'SampleCrowdSale: goal is greater than cap');
     });
   });

--- a/test/helpers/sign.js
+++ b/test/helpers/sign.js
@@ -47,7 +47,7 @@ const getSignFor = (contract, signer) => (redeemer, methodName, methodArgs = [])
     if (methodArgs.length > 0) {
       parts.push(
         contract.contract.methods[methodName](...methodArgs.concat([DUMMY_SIGNATURE])).encodeABI()
-          .slice(0, -1 * PADDED_SIGNATURE_SIZE)
+          .slice(0, -1 * PADDED_SIGNATURE_SIZE),
       );
     } else {
       const abi = contract.abi.find(abi => abi.name === methodName);

--- a/test/introspection/ERC1820Implementer.test.js
+++ b/test/introspection/ERC1820Implementer.test.js
@@ -29,9 +29,9 @@ describe('ERC1820Implementer', function () {
     it('reverts when attempting to set as implementer in the registry', async function () {
       await expectRevert(
         this.registry.setInterfaceImplementer(
-          implementee, this.interfaceA, this.implementer.address, { from: implementee }
+          implementee, this.interfaceA, this.implementer.address, { from: implementee },
         ),
-        'Does not implement the interface'
+        'Does not implement the interface',
       );
     });
   });
@@ -58,7 +58,7 @@ describe('ERC1820Implementer', function () {
 
     it('can be set as an implementer for supported interfaces in the registry', async function () {
       await this.registry.setInterfaceImplementer(
-        implementee, this.interfaceA, this.implementer.address, { from: implementee }
+        implementee, this.interfaceA, this.implementer.address, { from: implementee },
       );
 
       expect(await this.registry.getInterfaceImplementer(implementee, this.interfaceA))

--- a/test/lifecycle/Pausable.test.js
+++ b/test/lifecycle/Pausable.test.js
@@ -37,7 +37,7 @@ describe('Pausable', function () {
 
     it('cannot take drastic measure in non-pause', async function () {
       await expectRevert(this.pausable.drasticMeasure({ from: other }),
-        'Pausable: not paused'
+        'Pausable: not paused',
       );
       expect(await this.pausable.drasticMeasureTaken()).to.equal(false);
     });
@@ -50,7 +50,7 @@ describe('Pausable', function () {
 
       it('reverts when pausing from non-pauser', async function () {
         await expectRevert(this.pausable.pause({ from: other }),
-          'PauserRole: caller does not have the Pauser role'
+          'PauserRole: caller does not have the Pauser role',
         );
       });
 
@@ -84,7 +84,7 @@ describe('Pausable', function () {
 
           it('reverts when unpausing from non-pauser', async function () {
             await expectRevert(this.pausable.unpause({ from: other }),
-              'PauserRole: caller does not have the Pauser role'
+              'PauserRole: caller does not have the Pauser role',
             );
           });
 
@@ -105,7 +105,7 @@ describe('Pausable', function () {
 
             it('should prevent drastic measure', async function () {
               await expectRevert(this.pausable.drasticMeasure({ from: other }),
-                'Pausable: not paused'
+                'Pausable: not paused',
               );
             });
 

--- a/test/ownership/Ownable.behavior.js
+++ b/test/ownership/Ownable.behavior.js
@@ -21,14 +21,14 @@ function shouldBehaveLikeOwnable (owner, [other]) {
     it('should prevent non-owners from transferring', async function () {
       await expectRevert(
         this.ownable.transferOwnership(other, { from: other }),
-        'Ownable: caller is not the owner'
+        'Ownable: caller is not the owner',
       );
     });
 
     it('should guard ownership against stuck state', async function () {
       await expectRevert(
         this.ownable.transferOwnership(ZERO_ADDRESS, { from: owner }),
-        'Ownable: new owner is the zero address'
+        'Ownable: new owner is the zero address',
       );
     });
 
@@ -42,7 +42,7 @@ function shouldBehaveLikeOwnable (owner, [other]) {
     it('should prevent non-owners from renouncement', async function () {
       await expectRevert(
         this.ownable.renounceOwnership({ from: other }),
-        'Ownable: caller is not the owner'
+        'Ownable: caller is not the owner',
       );
     });
   });

--- a/test/ownership/Secondary.test.js
+++ b/test/ownership/Secondary.test.js
@@ -25,7 +25,7 @@ describe('Secondary', function () {
 
     it('reverts when anyone calls onlyPrimary functions', async function () {
       await expectRevert(this.secondary.onlyPrimaryMock({ from: other }),
-        'Secondary: caller is not the primary account'
+        'Secondary: caller is not the primary account',
       );
     });
   });
@@ -39,13 +39,13 @@ describe('Secondary', function () {
 
     it('reverts when transferring to the null address', async function () {
       await expectRevert(this.secondary.transferPrimary(ZERO_ADDRESS, { from: primary }),
-        'Secondary: new primary is the zero address'
+        'Secondary: new primary is the zero address',
       );
     });
 
     it('reverts when called by anyone', async function () {
       await expectRevert(this.secondary.transferPrimary(newPrimary, { from: other }),
-        'Secondary: caller is not the primary account'
+        'Secondary: caller is not the primary account',
       );
     });
 
@@ -60,7 +60,7 @@ describe('Secondary', function () {
 
       it('reverts when the old primary account calls onlyPrimary functions', async function () {
         await expectRevert(this.secondary.onlyPrimaryMock({ from: primary }),
-          'Secondary: caller is not the primary account'
+          'Secondary: caller is not the primary account',
         );
       });
     });

--- a/test/payment/PaymentSplitter.test.js
+++ b/test/payment/PaymentSplitter.test.js
@@ -18,31 +18,31 @@ describe('PaymentSplitter', function () {
 
   it('rejects more payees than shares', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee2, payee3], [20, 30]),
-      'PaymentSplitter: payees and shares length mismatch'
+      'PaymentSplitter: payees and shares length mismatch',
     );
   });
 
   it('rejects more shares than payees', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee2], [20, 30, 40]),
-      'PaymentSplitter: payees and shares length mismatch'
+      'PaymentSplitter: payees and shares length mismatch',
     );
   });
 
   it('rejects null payees', async function () {
     await expectRevert(PaymentSplitter.new([payee1, ZERO_ADDRESS], [20, 30]),
-      'PaymentSplitter: account is the zero address'
+      'PaymentSplitter: account is the zero address',
     );
   });
 
   it('rejects zero-valued shares', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee2], [20, 0]),
-      'PaymentSplitter: shares are 0'
+      'PaymentSplitter: shares are 0',
     );
   });
 
   it('rejects repeated payees', async function () {
     await expectRevert(PaymentSplitter.new([payee1, payee1], [20, 30]),
-      'PaymentSplitter: account already has shares'
+      'PaymentSplitter: account already has shares',
     );
   });
 
@@ -81,14 +81,14 @@ describe('PaymentSplitter', function () {
 
     it('should throw if no funds to claim', async function () {
       await expectRevert(this.contract.release(payee1),
-        'PaymentSplitter: account is not due payment'
+        'PaymentSplitter: account is not due payment',
       );
     });
 
     it('should throw if non-payee want to claim', async function () {
       await send.ether(payer1, this.contract.address, amount);
       await expectRevert(this.contract.release(nonpayee1),
-        'PaymentSplitter: account has no shares'
+        'PaymentSplitter: account has no shares',
       );
     });
 

--- a/test/payment/escrow/ConditionalEscrow.test.js
+++ b/test/payment/escrow/ConditionalEscrow.test.js
@@ -31,7 +31,7 @@ describe('ConditionalEscrow', function () {
       await this.escrow.deposit(payee, { from: owner, value: amount });
 
       await expectRevert(this.escrow.withdraw(payee, { from: owner }),
-        'ConditionalEscrow: payee is not allowed to withdraw'
+        'ConditionalEscrow: payee is not allowed to withdraw',
       );
     });
   });

--- a/test/payment/escrow/Escrow.behavior.js
+++ b/test/payment/escrow/Escrow.behavior.js
@@ -21,7 +21,7 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
 
       it('only the primary account can deposit', async function () {
         await expectRevert(this.escrow.deposit(payee1, { from: payee2 }),
-          'Secondary: caller is not the primary account'
+          'Secondary: caller is not the primary account',
         );
       });
 
@@ -73,7 +73,7 @@ function shouldBehaveLikeEscrow (primary, [payee1, payee2]) {
 
       it('only the primary account can withdraw', async function () {
         await expectRevert(this.escrow.withdraw(payee1, { from: payee1 }),
-          'Secondary: caller is not the primary account'
+          'Secondary: caller is not the primary account',
         );
       });
 

--- a/test/payment/escrow/RefundEscrow.test.js
+++ b/test/payment/escrow/RefundEscrow.test.js
@@ -15,7 +15,7 @@ describe('RefundEscrow', function () {
 
   it('requires a non-null beneficiary', async function () {
     await expectRevert(
-      RefundEscrow.new(ZERO_ADDRESS, { from: primary }), 'RefundEscrow: beneficiary is the zero address'
+      RefundEscrow.new(ZERO_ADDRESS, { from: primary }), 'RefundEscrow: beneficiary is the zero address',
     );
   });
 
@@ -39,21 +39,21 @@ describe('RefundEscrow', function () {
       it('does not refund refundees', async function () {
         await this.escrow.deposit(refundee1, { from: primary, value: amount });
         await expectRevert(this.escrow.withdraw(refundee1),
-          'ConditionalEscrow: payee is not allowed to withdraw'
+          'ConditionalEscrow: payee is not allowed to withdraw',
         );
       });
 
       it('does not allow beneficiary withdrawal', async function () {
         await this.escrow.deposit(refundee1, { from: primary, value: amount });
         await expectRevert(this.escrow.beneficiaryWithdraw(),
-          'RefundEscrow: beneficiary can only withdraw while closed'
+          'RefundEscrow: beneficiary can only withdraw while closed',
         );
       });
     });
 
     it('only the primary account can enter closed state', async function () {
       await expectRevert(this.escrow.close({ from: beneficiary }),
-        'Secondary: caller is not the primary account'
+        'Secondary: caller is not the primary account',
       );
 
       const { logs } = await this.escrow.close({ from: primary });
@@ -69,13 +69,13 @@ describe('RefundEscrow', function () {
 
       it('rejects deposits', async function () {
         await expectRevert(this.escrow.deposit(refundee1, { from: primary, value: amount }),
-          'RefundEscrow: can only deposit while active'
+          'RefundEscrow: can only deposit while active',
         );
       });
 
       it('does not refund refundees', async function () {
         await expectRevert(this.escrow.withdraw(refundee1),
-          'ConditionalEscrow: payee is not allowed to withdraw'
+          'ConditionalEscrow: payee is not allowed to withdraw',
         );
       });
 
@@ -87,20 +87,20 @@ describe('RefundEscrow', function () {
 
       it('prevents entering the refund state', async function () {
         await expectRevert(this.escrow.enableRefunds({ from: primary }),
-          'RefundEscrow: can only enable refunds while active'
+          'RefundEscrow: can only enable refunds while active',
         );
       });
 
       it('prevents re-entering the closed state', async function () {
         await expectRevert(this.escrow.close({ from: primary }),
-          'RefundEscrow: can only close while active'
+          'RefundEscrow: can only close while active',
         );
       });
     });
 
     it('only the primary account can enter refund state', async function () {
       await expectRevert(this.escrow.enableRefunds({ from: beneficiary }),
-        'Secondary: caller is not the primary account'
+        'Secondary: caller is not the primary account',
       );
 
       const { logs } = await this.escrow.enableRefunds({ from: primary });
@@ -116,7 +116,7 @@ describe('RefundEscrow', function () {
 
       it('rejects deposits', async function () {
         await expectRevert(this.escrow.deposit(refundee1, { from: primary, value: amount }),
-          'RefundEscrow: can only deposit while active'
+          'RefundEscrow: can only deposit while active',
         );
       });
 
@@ -130,19 +130,19 @@ describe('RefundEscrow', function () {
 
       it('does not allow beneficiary withdrawal', async function () {
         await expectRevert(this.escrow.beneficiaryWithdraw(),
-          'RefundEscrow: beneficiary can only withdraw while closed'
+          'RefundEscrow: beneficiary can only withdraw while closed',
         );
       });
 
       it('prevents entering the closed state', async function () {
         await expectRevert(this.escrow.close({ from: primary }),
-          'RefundEscrow: can only close while active'
+          'RefundEscrow: can only close while active',
         );
       });
 
       it('prevents re-entering the refund state', async function () {
         await expectRevert(this.escrow.enableRefunds({ from: primary }),
-          'RefundEscrow: can only enable refunds while active'
+          'RefundEscrow: can only enable refunds while active',
         );
       });
     });

--- a/test/token/ERC20/ERC20.behavior.js
+++ b/test/token/ERC20/ERC20.behavior.js
@@ -27,7 +27,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
     shouldBehaveLikeERC20Transfer(errorPrefix, initialHolder, recipient, initialSupply,
       function (from, to, value) {
         return this.token.transfer(to, value, { from });
-      }
+      },
     );
   });
 
@@ -88,7 +88,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
             it('reverts', async function () {
               await expectRevert(this.token.transferFrom(
-                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`
+                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`,
               );
             });
           });
@@ -104,7 +104,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
             it('reverts', async function () {
               await expectRevert(this.token.transferFrom(
-                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds allowance`
+                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds allowance`,
               );
             });
           });
@@ -114,7 +114,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
             it('reverts', async function () {
               await expectRevert(this.token.transferFrom(
-                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`
+                tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer amount exceeds balance`,
               );
             });
           });
@@ -131,7 +131,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
         it('reverts', async function () {
           await expectRevert(this.token.transferFrom(
-            tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`
+            tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer to the zero address`,
           );
         });
       });
@@ -144,7 +144,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
 
       it('reverts', async function () {
         await expectRevert(this.token.transferFrom(
-          tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer from the zero address`
+          tokenOwner, to, amount, { from: spender }), `${errorPrefix}: transfer from the zero address`,
         );
       });
     });
@@ -154,7 +154,7 @@ function shouldBehaveLikeERC20 (errorPrefix, initialSupply, initialHolder, recip
     shouldBehaveLikeERC20Approve(errorPrefix, initialHolder, recipient, initialSupply,
       function (owner, spender, amount) {
         return this.token.approve(spender, amount, { from: owner });
-      }
+      },
     );
   });
 }
@@ -166,7 +166,7 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
 
       it('reverts', async function () {
         await expectRevert(transfer.call(this, from, to, amount),
-          `${errorPrefix}: transfer amount exceeds balance`
+          `${errorPrefix}: transfer amount exceeds balance`,
         );
       });
     });
@@ -219,7 +219,7 @@ function shouldBehaveLikeERC20Transfer (errorPrefix, from, to, balance, transfer
   describe('when the recipient is the zero address', function () {
     it('reverts', async function () {
       await expectRevert(transfer.call(this, from, ZERO_ADDRESS, balance),
-        `${errorPrefix}: transfer to the zero address`
+        `${errorPrefix}: transfer to the zero address`,
       );
     });
   });
@@ -299,7 +299,7 @@ function shouldBehaveLikeERC20Approve (errorPrefix, owner, spender, supply, appr
   describe('when the spender is the zero address', function () {
     it('reverts', async function () {
       await expectRevert(approve.call(this, owner, ZERO_ADDRESS, supply),
-        `${errorPrefix}: approve to the zero address`
+        `${errorPrefix}: approve to the zero address`,
       );
     });
   });

--- a/test/token/ERC20/ERC20.test.js
+++ b/test/token/ERC20/ERC20.test.js
@@ -31,7 +31,7 @@ describe('ERC20', function () {
         describe('when there was no approved amount before', function () {
           it('reverts', async function () {
             await expectRevert(this.token.decreaseAllowance(
-              spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero'
+              spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero',
             );
           });
         });
@@ -67,7 +67,7 @@ describe('ERC20', function () {
           it('reverts when more than the full allowance is removed', async function () {
             await expectRevert(
               this.token.decreaseAllowance(spender, approvedAmount.addn(1), { from: initialHolder }),
-              'ERC20: decreased allowance below zero'
+              'ERC20: decreased allowance below zero',
             );
           });
         });
@@ -92,7 +92,7 @@ describe('ERC20', function () {
 
       it('reverts', async function () {
         await expectRevert(this.token.decreaseAllowance(
-          spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero'
+          spender, amount, { from: initialHolder }), 'ERC20: decreased allowance below zero',
         );
       });
     });
@@ -176,7 +176,7 @@ describe('ERC20', function () {
 
       it('reverts', async function () {
         await expectRevert(
-          this.token.increaseAllowance(spender, amount, { from: initialHolder }), 'ERC20: approve to the zero address'
+          this.token.increaseAllowance(spender, amount, { from: initialHolder }), 'ERC20: approve to the zero address',
         );
       });
     });
@@ -186,7 +186,7 @@ describe('ERC20', function () {
     const amount = new BN(50);
     it('rejects a null account', async function () {
       await expectRevert(
-        this.token.mint(ZERO_ADDRESS, amount), 'ERC20: mint to the zero address'
+        this.token.mint(ZERO_ADDRESS, amount), 'ERC20: mint to the zero address',
       );
     });
 
@@ -225,7 +225,7 @@ describe('ERC20', function () {
     describe('for a non zero account', function () {
       it('rejects burning more than balance', async function () {
         await expectRevert(this.token.burn(
-          initialHolder, initialSupply.addn(1)), 'ERC20: burn amount exceeds balance'
+          initialHolder, initialSupply.addn(1)), 'ERC20: burn amount exceeds balance',
         );
       });
 
@@ -273,20 +273,20 @@ describe('ERC20', function () {
 
     it('rejects a null account', async function () {
       await expectRevert(this.token.burnFrom(ZERO_ADDRESS, new BN(1)),
-        'ERC20: burn from the zero address'
+        'ERC20: burn from the zero address',
       );
     });
 
     describe('for a non zero account', function () {
       it('rejects burning more than allowance', async function () {
         await expectRevert(this.token.burnFrom(initialHolder, allowance.addn(1)),
-          'ERC20: burn amount exceeds allowance'
+          'ERC20: burn amount exceeds allowance',
         );
       });
 
       it('rejects burning more than balance', async function () {
         await expectRevert(this.token.burnFrom(initialHolder, initialSupply.addn(1)),
-          'ERC20: burn amount exceeds balance'
+          'ERC20: burn amount exceeds balance',
         );
       });
 
@@ -344,7 +344,7 @@ describe('ERC20', function () {
     describe('when the sender is the zero address', function () {
       it('reverts', async function () {
         await expectRevert(this.token.transferInternal(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: transfer from the zero address'
+          'ERC20: transfer from the zero address',
         );
       });
     });
@@ -358,7 +358,7 @@ describe('ERC20', function () {
     describe('when the owner is the zero address', function () {
       it('reverts', async function () {
         await expectRevert(this.token.approveInternal(ZERO_ADDRESS, recipient, initialSupply),
-          'ERC20: approve from the zero address'
+          'ERC20: approve from the zero address',
         );
       });
     });

--- a/test/token/ERC20/ERC20Capped.test.js
+++ b/test/token/ERC20/ERC20Capped.test.js
@@ -13,7 +13,7 @@ describe('ERC20Capped', function () {
 
   it('requires a non-zero cap', async function () {
     await expectRevert(
-      ERC20Capped.new(new BN(0), { from: minter }), 'ERC20Capped: cap is 0'
+      ERC20Capped.new(new BN(0), { from: minter }), 'ERC20Capped: cap is 0',
     );
   });
 

--- a/test/token/ERC20/ERC20Pausable.test.js
+++ b/test/token/ERC20/ERC20Pausable.test.js
@@ -58,7 +58,7 @@ describe('ERC20Pausable', function () {
 
       it('reverts', async function () {
         await expectRevert(this.token.pause({ from }),
-          'PauserRole: caller does not have the Pauser role'
+          'PauserRole: caller does not have the Pauser role',
         );
       });
     });
@@ -97,7 +97,7 @@ describe('ERC20Pausable', function () {
 
       it('reverts', async function () {
         await expectRevert(this.token.unpause({ from }),
-          'PauserRole: caller does not have the Pauser role'
+          'PauserRole: caller does not have the Pauser role',
         );
       });
     });
@@ -145,7 +145,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause({ from: pauser });
 
         await expectRevert(this.token.transfer(recipient, initialSupply, { from: pauser }),
-          'Pausable: paused'
+          'Pausable: paused',
         );
       });
     });
@@ -172,7 +172,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause({ from: pauser });
 
         await expectRevert(this.token.approve(anotherAccount, allowance, { from: pauser }),
-          'Pausable: paused'
+          'Pausable: paused',
         );
       });
     });
@@ -205,7 +205,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause({ from: pauser });
 
         await expectRevert(this.token.transferFrom(
-          pauser, recipient, allowance, { from: anotherAccount }), 'Pausable: paused'
+          pauser, recipient, allowance, { from: anotherAccount }), 'Pausable: paused',
         );
       });
     });
@@ -237,7 +237,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause({ from: pauser });
 
         await expectRevert(this.token.decreaseAllowance(
-          anotherAccount, decrement, { from: pauser }), 'Pausable: paused'
+          anotherAccount, decrement, { from: pauser }), 'Pausable: paused',
         );
       });
     });
@@ -269,7 +269,7 @@ describe('ERC20Pausable', function () {
         await this.token.pause({ from: pauser });
 
         await expectRevert(this.token.increaseAllowance(
-          anotherAccount, increment, { from: pauser }), 'Pausable: paused'
+          anotherAccount, increment, { from: pauser }), 'Pausable: paused',
         );
       });
     });

--- a/test/token/ERC20/SafeERC20.test.js
+++ b/test/token/ERC20/SafeERC20.test.js
@@ -97,7 +97,7 @@ function shouldOnlyRevertOnErrors () {
       it('reverts when decreasing the allowance', async function () {
         await expectRevert(
           this.wrapper.decreaseAllowance(10),
-          'SafeERC20: decreased allowance below zero'
+          'SafeERC20: decreased allowance below zero',
         );
       });
     });
@@ -110,7 +110,7 @@ function shouldOnlyRevertOnErrors () {
       it('reverts when approving a non-zero allowance', async function () {
         await expectRevert(
           this.wrapper.approve(20),
-          'SafeERC20: approve from non-zero to non-zero allowance'
+          'SafeERC20: approve from non-zero to non-zero allowance',
         );
       });
 
@@ -129,7 +129,7 @@ function shouldOnlyRevertOnErrors () {
       it('reverts when decreasing the allowance to a negative value', async function () {
         await expectRevert(
           this.wrapper.decreaseAllowance(200),
-          'SafeERC20: decreased allowance below zero'
+          'SafeERC20: decreased allowance below zero',
         );
       });
     });

--- a/test/token/ERC20/StandaloneERC20.test.js
+++ b/test/token/ERC20/StandaloneERC20.test.js
@@ -8,7 +8,7 @@ require('chai').should();
 const StandaloneERC20 = contract.fromArtifact('StandaloneERC20');
 
 describe('StandaloneERC20', function () {
-  const [ deployer, initialHolder, minterA, minterB, pauserA, pauserB, anyone, ...otherAccounts ] = accounts;
+  const [ deployer, initialHolder, minterA, minterB, pauserA, pauserB, ...otherAccounts ] = accounts;
 
   const name = 'StandaloneERC20';
   const symbol = 'SAERC20';
@@ -40,7 +40,7 @@ describe('StandaloneERC20', function () {
   describe('with all arguments', function () {
     it('reverts if initial balance is zero', async function () {
       await expectRevert.unspecified(
-        initializeFull(this.token, name, symbol, decimals, 0, ZERO_ADDRESS, minters, pausers, deployer)
+        initializeFull(this.token, name, symbol, decimals, 0, ZERO_ADDRESS, minters, pausers, deployer),
       );
     });
 
@@ -63,7 +63,7 @@ describe('StandaloneERC20', function () {
     context('with token', async function () {
       beforeEach(async function () {
         await initializeFull(
-          this.token, name, symbol, decimals, initialSupply, initialHolder, minters, pausers, deployer
+          this.token, name, symbol, decimals, initialSupply, initialHolder, minters, pausers, deployer,
         );
       });
 

--- a/test/token/ERC20/TokenTimelock.test.js
+++ b/test/token/ERC20/TokenTimelock.test.js
@@ -21,7 +21,7 @@ describe('TokenTimelock', function () {
       const pastReleaseTime = (await time.latest()).sub(time.duration.years(1));
       await expectRevert(
         TokenTimelock.new(this.token.address, beneficiary, pastReleaseTime),
-        'TokenTimelock: release time is before current time'
+        'TokenTimelock: release time is before current time',
       );
     });
 

--- a/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Burnable.behavior.js
@@ -38,7 +38,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
 
       it('reverts', async function () {
         await expectRevert(this.token.burn(amount, { from: owner }),
-          'ERC20: burn amount exceeds balance'
+          'ERC20: burn amount exceeds balance',
         );
       });
     });
@@ -87,7 +87,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
       it('reverts', async function () {
         await this.token.approve(burner, amount, { from: owner });
         await expectRevert(this.token.burnFrom(owner, amount, { from: burner }),
-          'ERC20: burn amount exceeds balance'
+          'ERC20: burn amount exceeds balance',
         );
       });
     });
@@ -98,7 +98,7 @@ function shouldBehaveLikeERC20Burnable (owner, initialBalance, [burner]) {
       it('reverts', async function () {
         await this.token.approve(burner, allowance, { from: owner });
         await expectRevert(this.token.burnFrom(owner, allowance.addn(1), { from: burner }),
-          'ERC20: burn amount exceeds allowance'
+          'ERC20: burn amount exceeds allowance',
         );
       });
     });

--- a/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
+++ b/test/token/ERC20/behaviors/ERC20Mintable.behavior.js
@@ -43,7 +43,7 @@ function shouldBehaveLikeERC20Mintable (minter, [other]) {
 
         it('reverts', async function () {
           await expectRevert(this.token.mint(other, amount, { from }),
-            'MinterRole: caller does not have the Minter role'
+            'MinterRole: caller does not have the Minter role',
           );
         });
       });

--- a/test/token/ERC721/ERC721.behavior.js
+++ b/test/token/ERC721/ERC721.behavior.js
@@ -10,7 +10,7 @@ const ERC721ReceiverMock = contract.fromArtifact('ERC721ReceiverMock');
 function shouldBehaveLikeERC721 (
   creator,
   minter,
-  [owner, approved, anotherApproved, operator, other]
+  [owner, approved, anotherApproved, operator, other],
 ) {
   const firstTokenId = new BN(1);
   const secondTokenId = new BN(2);
@@ -40,7 +40,7 @@ function shouldBehaveLikeERC721 (
       context('when querying the zero address', function () {
         it('throws', async function () {
           await expectRevert(
-            this.token.balanceOf(ZERO_ADDRESS), 'ERC721: balance query for the zero address'
+            this.token.balanceOf(ZERO_ADDRESS), 'ERC721: balance query for the zero address',
           );
         });
       });
@@ -60,7 +60,7 @@ function shouldBehaveLikeERC721 (
 
         it('reverts', async function () {
           await expectRevert(
-            this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
+            this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token',
           );
         });
       });
@@ -175,10 +175,10 @@ function shouldBehaveLikeERC721 (
           it('keeps same tokens by index', async function () {
             if (!this.token.tokenOfOwnerByIndex) return;
             const tokensListed = await Promise.all(
-              [0, 1].map(i => this.token.tokenOfOwnerByIndex(owner, i))
+              [0, 1].map(i => this.token.tokenOfOwnerByIndex(owner, i)),
             );
             expect(tokensListed.map(t => t.toNumber())).to.have.members(
-              [firstTokenId.toNumber(), secondTokenId.toNumber()]
+              [firstTokenId.toNumber(), secondTokenId.toNumber()],
             );
           });
         });
@@ -187,7 +187,7 @@ function shouldBehaveLikeERC721 (
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, other, other, tokenId, { from: owner }),
-              'ERC721: transfer of token that is not own'
+              'ERC721: transfer of token that is not own',
             );
           });
         });
@@ -196,7 +196,7 @@ function shouldBehaveLikeERC721 (
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, other, tokenId, { from: other }),
-              'ERC721: transfer caller is not owner nor approved'
+              'ERC721: transfer caller is not owner nor approved',
             );
           });
         });
@@ -205,7 +205,7 @@ function shouldBehaveLikeERC721 (
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, other, unknownTokenId, { from: owner }),
-              'ERC721: operator query for nonexistent token'
+              'ERC721: operator query for nonexistent token',
             );
           });
         });
@@ -214,7 +214,7 @@ function shouldBehaveLikeERC721 (
           it('reverts', async function () {
             await expectRevert(
               transferFunction.call(this, owner, ZERO_ADDRESS, tokenId, { from: owner }),
-              'ERC721: transfer to the zero address'
+              'ERC721: transfer to the zero address',
             );
           });
         });
@@ -280,7 +280,7 @@ function shouldBehaveLikeERC721 (
                     unknownTokenId,
                     { from: owner },
                   ),
-                  'ERC721: operator query for nonexistent token'
+                  'ERC721: operator query for nonexistent token',
                 );
               });
             });
@@ -300,7 +300,7 @@ function shouldBehaveLikeERC721 (
             const invalidReceiver = await ERC721ReceiverMock.new('0x42', false);
             await expectRevert(
               this.token.safeTransferFrom(owner, invalidReceiver.address, tokenId, { from: owner }),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -310,7 +310,7 @@ function shouldBehaveLikeERC721 (
             const revertingReceiver = await ERC721ReceiverMock.new(RECEIVER_MAGIC_VALUE, true);
             await expectRevert(
               this.token.safeTransferFrom(owner, revertingReceiver.address, tokenId, { from: owner }),
-              'ERC721ReceiverMock: reverting'
+              'ERC721ReceiverMock: reverting',
             );
           });
         });
@@ -320,7 +320,7 @@ function shouldBehaveLikeERC721 (
             const nonReceiver = this.token;
             await expectRevert(
               this.token.safeTransferFrom(owner, nonReceiver.address, tokenId, { from: owner }),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -363,7 +363,7 @@ function shouldBehaveLikeERC721 (
             const invalidReceiver = await ERC721ReceiverMock.new('0x42', false);
             await expectRevert(
               this.ERC721Mock.safeMint(invalidReceiver.address, tokenId),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -373,7 +373,7 @@ function shouldBehaveLikeERC721 (
             const revertingReceiver = await ERC721ReceiverMock.new(RECEIVER_MAGIC_VALUE, true);
             await expectRevert(
               this.ERC721Mock.safeMint(revertingReceiver.address, tokenId),
-              'ERC721ReceiverMock: reverting'
+              'ERC721ReceiverMock: reverting',
             );
           });
         });
@@ -383,7 +383,7 @@ function shouldBehaveLikeERC721 (
             const nonReceiver = this.token;
             await expectRevert(
               this.ERC721Mock.safeMint(nonReceiver.address, tokenId),
-              'ERC721: transfer to non ERC721Receiver implementer'
+              'ERC721: transfer to non ERC721Receiver implementer',
             );
           });
         });
@@ -472,7 +472,7 @@ function shouldBehaveLikeERC721 (
       context('when the address that receives the approval is the owner', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.approve(owner, tokenId, { from: owner }), 'ERC721: approval to current owner'
+            this.token.approve(owner, tokenId, { from: owner }), 'ERC721: approval to current owner',
           );
         });
       });
@@ -594,7 +594,7 @@ function shouldBehaveLikeERC721 (
         it('reverts', async function () {
           await expectRevert(
             this.token.getApproved(unknownTokenId, { from: minter }),
-            'ERC721: approved query for nonexistent token'
+            'ERC721: approved query for nonexistent token',
           );
         });
       });
@@ -602,7 +602,7 @@ function shouldBehaveLikeERC721 (
       context('when token has been minted ', async function () {
         it('should return the zero address', async function () {
           expect(await this.token.getApproved(firstTokenId)).to.be.equal(
-            ZERO_ADDRESS
+            ZERO_ADDRESS,
           );
         });
 

--- a/test/token/ERC721/ERC721.test.js
+++ b/test/token/ERC721/ERC721.test.js
@@ -23,7 +23,7 @@ describe('ERC721', function () {
     describe('_mint(address, uint256)', function () {
       it('reverts with a null destination address', async function () {
         await expectRevert(
-          this.token.mint(ZERO_ADDRESS, tokenId), 'ERC721: mint to the zero address'
+          this.token.mint(ZERO_ADDRESS, tokenId), 'ERC721: mint to the zero address',
         );
       });
 
@@ -50,7 +50,7 @@ describe('ERC721', function () {
     describe('_burn(address, uint256)', function () {
       it('reverts when burning a non-existent token id', async function () {
         await expectRevert(
-          this.token.methods['burn(address,uint256)'](owner, tokenId), 'ERC721: owner query for nonexistent token'
+          this.token.methods['burn(address,uint256)'](owner, tokenId), 'ERC721: owner query for nonexistent token',
         );
       });
 
@@ -61,7 +61,7 @@ describe('ERC721', function () {
 
         it('reverts when the account is not the owner', async function () {
           await expectRevert(
-            this.token.methods['burn(address,uint256)'](other, tokenId), 'ERC721: burn of token that is not own'
+            this.token.methods['burn(address,uint256)'](other, tokenId), 'ERC721: burn of token that is not own',
           );
         });
 
@@ -77,14 +77,14 @@ describe('ERC721', function () {
           it('deletes the token', async function () {
             expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('0');
             await expectRevert(
-              this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
+              this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token',
             );
           });
 
           it('reverts when burning a token id that has been deleted', async function () {
             await expectRevert(
               this.token.methods['burn(address,uint256)'](owner, tokenId),
-              'ERC721: owner query for nonexistent token'
+              'ERC721: owner query for nonexistent token',
             );
           });
         });
@@ -94,7 +94,7 @@ describe('ERC721', function () {
     describe('_burn(uint256)', function () {
       it('reverts when burning a non-existent token id', async function () {
         await expectRevert(
-          this.token.methods['burn(uint256)'](tokenId), 'ERC721: owner query for nonexistent token'
+          this.token.methods['burn(uint256)'](tokenId), 'ERC721: owner query for nonexistent token',
         );
       });
 
@@ -115,13 +115,13 @@ describe('ERC721', function () {
           it('deletes the token', async function () {
             expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('0');
             await expectRevert(
-              this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token'
+              this.token.ownerOf(tokenId), 'ERC721: owner query for nonexistent token',
             );
           });
 
           it('reverts when burning a token id that has been deleted', async function () {
             await expectRevert(
-              this.token.methods['burn(uint256)'](tokenId), 'ERC721: owner query for nonexistent token'
+              this.token.methods['burn(uint256)'](tokenId), 'ERC721: owner query for nonexistent token',
             );
           });
         });

--- a/test/token/ERC721/ERC721Full.test.js
+++ b/test/token/ERC721/ERC721Full.test.js
@@ -66,7 +66,7 @@ describe('ERC721Full', function () {
         await this.token.burn(secondTokenId, { from: owner });
         expect(await this.token.totalSupply()).to.be.bignumber.equal('0');
         await expectRevert(
-          this.token.tokenByIndex(0), 'ERC721Enumerable: global index out of bounds'
+          this.token.tokenByIndex(0), 'ERC721Enumerable: global index out of bounds',
         );
       });
     });
@@ -90,7 +90,7 @@ describe('ERC721Full', function () {
 
         it('reverts when queried for non existent token id', async function () {
           await expectRevert(
-            this.token.tokenURI(nonExistentTokenId), 'ERC721Metadata: URI query for nonexistent token'
+            this.token.tokenURI(nonExistentTokenId), 'ERC721Metadata: URI query for nonexistent token',
           );
         });
 
@@ -101,7 +101,7 @@ describe('ERC721Full', function () {
 
         it('reverts when setting for non existent token id', async function () {
           await expectRevert(
-            this.token.setTokenURI(nonExistentTokenId, sampleUri), 'ERC721Metadata: URI set of nonexistent token'
+            this.token.setTokenURI(nonExistentTokenId, sampleUri), 'ERC721Metadata: URI set of nonexistent token',
           );
         });
 
@@ -139,7 +139,7 @@ describe('ERC721Full', function () {
 
           expect(await this.token.exists(firstTokenId)).to.equal(false);
           await expectRevert(
-            this.token.tokenURI(firstTokenId), 'ERC721Metadata: URI query for nonexistent token'
+            this.token.tokenURI(firstTokenId), 'ERC721Metadata: URI query for nonexistent token',
           );
         });
       });
@@ -170,7 +170,7 @@ describe('ERC721Full', function () {
       describe('when the index is greater than or equal to the total tokens owned by the given address', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(owner, 2), 'ERC721Enumerable: owner index out of bounds'
+            this.token.tokenOfOwnerByIndex(owner, 2), 'ERC721Enumerable: owner index out of bounds',
           );
         });
       });
@@ -178,7 +178,7 @@ describe('ERC721Full', function () {
       describe('when the given address does not own any token', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(other, 0), 'ERC721Enumerable: owner index out of bounds'
+            this.token.tokenOfOwnerByIndex(other, 0), 'ERC721Enumerable: owner index out of bounds',
           );
         });
       });
@@ -192,7 +192,7 @@ describe('ERC721Full', function () {
         it('returns correct token IDs for target', async function () {
           expect(await this.token.balanceOf(other)).to.be.bignumber.equal('2');
           const tokensListed = await Promise.all(
-            [0, 1].map(i => this.token.tokenOfOwnerByIndex(other, i))
+            [0, 1].map(i => this.token.tokenOfOwnerByIndex(other, i)),
           );
           expect(tokensListed.map(t => t.toNumber())).to.have.members([firstTokenId.toNumber(),
             secondTokenId.toNumber()]);
@@ -201,7 +201,7 @@ describe('ERC721Full', function () {
         it('returns empty collection for original owner', async function () {
           expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('0');
           await expectRevert(
-            this.token.tokenOfOwnerByIndex(owner, 0), 'ERC721Enumerable: owner index out of bounds'
+            this.token.tokenOfOwnerByIndex(owner, 0), 'ERC721Enumerable: owner index out of bounds',
           );
         });
       });
@@ -210,7 +210,7 @@ describe('ERC721Full', function () {
     describe('tokenByIndex', function () {
       it('should return all tokens', async function () {
         const tokensListed = await Promise.all(
-          [0, 1].map(i => this.token.tokenByIndex(i))
+          [0, 1].map(i => this.token.tokenByIndex(i)),
         );
         expect(tokensListed.map(t => t.toNumber())).to.have.members([firstTokenId.toNumber(),
           secondTokenId.toNumber()]);
@@ -218,7 +218,7 @@ describe('ERC721Full', function () {
 
       it('should revert if index is greater than supply', async function () {
         await expectRevert(
-          this.token.tokenByIndex(2), 'ERC721Enumerable: global index out of bounds'
+          this.token.tokenByIndex(2), 'ERC721Enumerable: global index out of bounds',
         );
       });
 
@@ -234,10 +234,10 @@ describe('ERC721Full', function () {
           expect(await this.token.totalSupply()).to.be.bignumber.equal('3');
 
           const tokensListed = await Promise.all(
-            [0, 1, 2].map(i => this.token.tokenByIndex(i))
+            [0, 1, 2].map(i => this.token.tokenByIndex(i)),
           );
           const expectedTokens = [firstTokenId, secondTokenId, newTokenId, anotherNewTokenId].filter(
-            x => (x !== tokenId)
+            x => (x !== tokenId),
           );
           expect(tokensListed.map(t => t.toNumber())).to.have.members(expectedTokens.map(t => t.toNumber()));
         });

--- a/test/token/ERC721/ERC721MintBurn.behavior.js
+++ b/test/token/ERC721/ERC721MintBurn.behavior.js
@@ -6,7 +6,7 @@ const { expect } = require('chai');
 function shouldBehaveLikeMintAndBurnERC721 (
   creator,
   minter,
-  [owner, newOwner, approved]
+  [owner, newOwner, approved],
 ) {
   const firstTokenId = new BN(1);
   const secondTokenId = new BN(2);
@@ -51,7 +51,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
         it('reverts', async function () {
           await expectRevert(
             this.token.mint(ZERO_ADDRESS, thirdTokenId, { from: minter }),
-            'ERC721: mint to the zero address'
+            'ERC721: mint to the zero address',
           );
         });
       });
@@ -59,7 +59,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
       describe('when the given token ID was already tracked by this contract', function () {
         it('reverts', async function () {
           await expectRevert(this.token.mint(owner, firstTokenId, { from: minter }),
-            'ERC721: token already minted.'
+            'ERC721: token already minted.',
           );
         });
       });
@@ -98,7 +98,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
         it('burns the given token ID and adjusts the balance of the owner', async function () {
           await expectRevert(
             this.token.ownerOf(tokenId),
-            'ERC721: owner query for nonexistent token'
+            'ERC721: owner query for nonexistent token',
           );
           expect(await this.token.balanceOf(owner)).to.be.bignumber.equal('1');
         });
@@ -122,7 +122,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
         context('getApproved', function () {
           it('reverts', async function () {
             await expectRevert(
-              this.token.getApproved(tokenId), 'ERC721: approved query for nonexistent token'
+              this.token.getApproved(tokenId), 'ERC721: approved query for nonexistent token',
             );
           });
         });
@@ -131,7 +131,7 @@ function shouldBehaveLikeMintAndBurnERC721 (
       describe('when the given token ID was not tracked by this contract', function () {
         it('reverts', async function () {
           await expectRevert(
-            this.token.burn(unknownTokenId, { from: creator }), 'ERC721: operator query for nonexistent token'
+            this.token.burn(unknownTokenId, { from: creator }), 'ERC721: operator query for nonexistent token',
           );
         });
       });

--- a/test/token/ERC721/ERC721PausedToken.behavior.js
+++ b/test/token/ERC721/ERC721PausedToken.behavior.js
@@ -15,33 +15,33 @@ function shouldBehaveLikeERC721PausedToken (owner, [receiver, operator]) {
 
     it('reverts when trying to approve', async function () {
       await expectRevert(
-        this.token.approve(receiver, firstTokenId, { from: owner }), 'Pausable: paused'
+        this.token.approve(receiver, firstTokenId, { from: owner }), 'Pausable: paused',
       );
     });
 
     it('reverts when trying to setApprovalForAll', async function () {
       await expectRevert(
-        this.token.setApprovalForAll(operator, true, { from: owner }), 'Pausable: paused'
+        this.token.setApprovalForAll(operator, true, { from: owner }), 'Pausable: paused',
       );
     });
 
     it('reverts when trying to transferFrom', async function () {
       await expectRevert(
-        this.token.transferFrom(owner, receiver, firstTokenId, { from: owner }), 'Pausable: paused'
+        this.token.transferFrom(owner, receiver, firstTokenId, { from: owner }), 'Pausable: paused',
       );
     });
 
     it('reverts when trying to safeTransferFrom', async function () {
       await expectRevert(
-        this.token.safeTransferFrom(owner, receiver, firstTokenId, { from: owner }), 'Pausable: paused'
+        this.token.safeTransferFrom(owner, receiver, firstTokenId, { from: owner }), 'Pausable: paused',
       );
     });
 
     it('reverts when trying to safeTransferFrom with data', async function () {
       await expectRevert(
         this.token.methods['safeTransferFrom(address,address,uint256,bytes)'](
-          owner, receiver, firstTokenId, mockData, { from: owner }
-        ), 'Pausable: paused'
+          owner, receiver, firstTokenId, mockData, { from: owner },
+        ), 'Pausable: paused',
       );
     });
 

--- a/test/token/ERC721/StandaloneERC721.test.js
+++ b/test/token/ERC721/StandaloneERC721.test.js
@@ -5,7 +5,7 @@ require('chai').should();
 const StandaloneERC721 = contract.fromArtifact('StandaloneERC721');
 
 describe('StandaloneERC721', function () {
-  const [ deployer, minterA, minterB, pauserA, pauserB, anyone, ...otherAccounts] = accounts;
+  const [ deployer, minterA, minterB, pauserA, pauserB] = accounts;
   const name = 'StandaloneERC721';
   const symbol = 'SAERC721';
 

--- a/test/token/ERC777/ERC777.behavior.js
+++ b/test/token/ERC777/ERC777.behavior.js
@@ -58,15 +58,15 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
       it('reverts when sending more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
         await expectRevert.unspecified(
-          this.token.operatorSend(holder, recipient, balance.addn(1), data, operatorData, { from: operator })
+          this.token.operatorSend(holder, recipient, balance.addn(1), data, operatorData, { from: operator }),
         );
       });
 
       it('reverts when sending to the zero address', async function () {
         await expectRevert.unspecified(
           this.token.operatorSend(
-            holder, ZERO_ADDRESS, new BN('1'), data, operatorData, { from: operator }
-          )
+            holder, ZERO_ADDRESS, new BN('1'), data, operatorData, { from: operator },
+          ),
         );
       });
     });
@@ -78,7 +78,7 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
 
       it('reverts when sending a non-zero amount', async function () {
         await expectRevert.unspecified(
-          this.token.operatorSend(holder, recipient, new BN('1'), data, operatorData, { from: operator })
+          this.token.operatorSend(holder, recipient, new BN('1'), data, operatorData, { from: operator }),
         );
       });
 
@@ -86,8 +86,8 @@ function shouldBehaveLikeERC777OperatorSend (holder, recipient, operator, data, 
         // This is not yet reflected in the spec
         await expectRevert.unspecified(
           this.token.operatorSend(
-            ZERO_ADDRESS, recipient, new BN('0'), data, operatorData, { from: operator }
-          )
+            ZERO_ADDRESS, recipient, new BN('0'), data, operatorData, { from: operator },
+          ),
         );
       });
     });
@@ -135,7 +135,7 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
       it('reverts when burning more than the balance', async function () {
         const balance = await this.token.balanceOf(holder);
         await expectRevert.unspecified(
-          this.token.operatorBurn(holder, balance.addn(1), data, operatorData, { from: operator })
+          this.token.operatorBurn(holder, balance.addn(1), data, operatorData, { from: operator }),
         );
       });
     });
@@ -147,7 +147,7 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
 
       it('reverts when burning a non-zero amount', async function () {
         await expectRevert.unspecified(
-          this.token.operatorBurn(holder, new BN('1'), data, operatorData, { from: operator })
+          this.token.operatorBurn(holder, new BN('1'), data, operatorData, { from: operator }),
         );
       });
 
@@ -155,8 +155,8 @@ function shouldBehaveLikeERC777OperatorBurn (holder, operator, data, operatorDat
         // This is not yet reflected in the spec
         await expectRevert.unspecified(
           this.token.operatorBurn(
-            ZERO_ADDRESS, new BN('0'), data, operatorData, { from: operator }
-          )
+            ZERO_ADDRESS, new BN('0'), data, operatorData, { from: operator },
+          ),
         );
       });
     });
@@ -326,13 +326,13 @@ function shouldBehaveLikeERC777SendBurnMintInternalWithReceiveHook (operator, am
 
     it('operatorSend reverts', async function () {
       await expectRevert.unspecified(
-        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator })
+        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator }),
       );
     });
 
     it('mint (internal) reverts', async function () {
       await expectRevert.unspecified(
-        this.token.mintInternal(operator, this.recipient, amount, data, operatorData)
+        this.token.mintInternal(operator, this.recipient, amount, data, operatorData),
       );
     });
   });
@@ -420,7 +420,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
 
     it('operatorSend reverts', async function () {
       await expectRevert.unspecified(
-        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator })
+        this.token.operatorSend(this.sender, this.recipient, amount, data, operatorData, { from: operator }),
       );
     });
 
@@ -430,7 +430,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
 
     it('operatorBurn reverts', async function () {
       await expectRevert.unspecified(
-        this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator })
+        this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator }),
       );
     });
   });
@@ -489,7 +489,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
       const { tx } = await burnFromHolder(this.token, this.sender, amount, data, { from: this.sender });
 
       await assertTokensToSendCalled(
-        this.token, tx, this.sender, this.sender, ZERO_ADDRESS, amount, data, null, preSenderBalance
+        this.token, tx, this.sender, this.sender, ZERO_ADDRESS, amount, data, null, preSenderBalance,
       );
     });
 
@@ -499,7 +499,7 @@ function shouldBehaveLikeERC777SendBurnWithSendHook (operator, amount, data, ope
       const { tx } = await this.token.operatorBurn(this.sender, amount, data, operatorData, { from: operator });
 
       await assertTokensToSendCalled(
-        this.token, tx, operator, this.sender, ZERO_ADDRESS, amount, data, operatorData, preSenderBalance
+        this.token, tx, operator, this.sender, ZERO_ADDRESS, amount, data, operatorData, preSenderBalance,
       );
     });
   });

--- a/test/token/ERC777/ERC777.test.js
+++ b/test/token/ERC777/ERC777.test.js
@@ -164,13 +164,13 @@ describe('ERC777', function () {
 
       it('reverts when self-authorizing', async function () {
         await expectRevert(
-          this.token.authorizeOperator(holder, { from: holder }), 'ERC777: authorizing self as operator'
+          this.token.authorizeOperator(holder, { from: holder }), 'ERC777: authorizing self as operator',
         );
       });
 
       it('reverts when self-revoking', async function () {
         await expectRevert(
-          this.token.revokeOperator(holder, { from: holder }), 'ERC777: revoking self as operator'
+          this.token.revokeOperator(holder, { from: holder }), 'ERC777: revoking self as operator',
         );
       });
 
@@ -234,7 +234,7 @@ describe('ERC777', function () {
         it('cannot be revoked for themselves', async function () {
           await expectRevert(
             this.token.revokeOperator(defaultOperatorA, { from: defaultOperatorA }),
-            'ERC777: revoking self as operator'
+            'ERC777: revoking self as operator',
           );
         });
 

--- a/test/utils/Address.test.js
+++ b/test/utils/Address.test.js
@@ -101,7 +101,7 @@ describe('Address', function () {
           await this.contractRecipient.setAcceptEther(false);
           await expectRevert(
             this.mock.sendValue(this.contractRecipient.address, funds),
-            'Address: unable to send value, recipient may have reverted'
+            'Address: unable to send value, recipient may have reverted',
           );
         });
       });

--- a/test/utils/Create2.test.js
+++ b/test/utils/Create2.test.js
@@ -56,7 +56,7 @@ describe('Create2', function () {
   it('should failed deploying a contract in an existent address', async function () {
     await this.factory.deploy(saltHex, constructorByteCode, { from: deployerAccount });
     await expectRevert(
-      this.factory.deploy(saltHex, constructorByteCode, { from: deployerAccount }), 'Create2: Failed on deploy'
+      this.factory.deploy(saltHex, constructorByteCode, { from: deployerAccount }), 'Create2: Failed on deploy',
     );
   });
 });

--- a/test/utils/EnumerableSet.test.js
+++ b/test/utils/EnumerableSet.test.js
@@ -13,7 +13,7 @@ describe('EnumerableSet', function () {
 
   async function expectMembersMatch (set, members) {
     await Promise.all(members.map(async account =>
-      expect(await set.contains(account)).to.equal(true)
+      expect(await set.contains(account)).to.equal(true),
     ));
 
     expect(await set.enumerate()).to.have.same.members(members);
@@ -21,7 +21,7 @@ describe('EnumerableSet', function () {
     expect(await set.length()).to.bignumber.equal(members.length.toString());
 
     expect(await Promise.all([...Array(members.length).keys()].map(index =>
-      set.get(index)
+      set.get(index),
     ))).to.have.same.members(members);
   }
 

--- a/test/utils/ReentrancyGuard.test.js
+++ b/test/utils/ReentrancyGuard.test.js
@@ -24,13 +24,13 @@ describe('ReentrancyGuard', function () {
 
   it('should not allow local recursion', async function () {
     await expectRevert(
-      this.reentrancyMock.countLocalRecursive(10), 'ReentrancyGuard: reentrant call'
+      this.reentrancyMock.countLocalRecursive(10), 'ReentrancyGuard: reentrant call',
     );
   });
 
   it('should not allow indirect local recursion', async function () {
     await expectRevert(
-      this.reentrancyMock.countThisRecursive(10), 'ReentrancyMock: failed call'
+      this.reentrancyMock.countThisRecursive(10), 'ReentrancyMock: failed call',
     );
   });
 });

--- a/test/utils/SafeCast.test.js
+++ b/test/utils/SafeCast.test.js
@@ -29,14 +29,14 @@ describe('SafeCast', async () => {
       it(`reverts when downcasting 2^${bits} (${maxValue.addn(1)})`, async function () {
         await expectRevert(
           this.safeCast[`toUint${bits}`](maxValue.addn(1)),
-          `SafeCast: value doesn't fit in ${bits} bits`
+          `SafeCast: value doesn't fit in ${bits} bits`,
         );
       });
 
       it(`reverts when downcasting 2^${bits} + 1 (${maxValue.addn(2)})`, async function () {
         await expectRevert(
           this.safeCast[`toUint${bits}`](maxValue.addn(2)),
-          `SafeCast: value doesn't fit in ${bits} bits`
+          `SafeCast: value doesn't fit in ${bits} bits`,
         );
       });
     });


### PR DESCRIPTION
The deployment of the new version using the OZ CLI failed because the new variable `_baseUri` in `ERC721Metadata` was placed in the middle instead of the end.