### PR TITLE
Deploy v2.5 contracts

### DIFF
--- a/.openzeppelin/kovan.json
+++ b/.openzeppelin/kovan.json
@@ -1,233 +1,11 @@
 {
   "contracts": {
-    "StandaloneERC20": {
-      "address": "0x77172f931948C164f79a360F014D75D88A5c45e8",
-      "constructorCode": "60806040525b5b61000b565b61372e8061001a6000396000f3fe",
-      "bodyBytecodeHash": "e85eba9d1581c280b848dcd3b157b8b519012a715adc705ed19e0e3b2d1331fe",
-      "localBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "deployedBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_string": {
-          "id": "t_string",
-          "kind": "elementary",
-          "label": "string"
-        },
-        "t_uint8": {
-          "id": "t_uint8",
-          "kind": "elementary",
-          "label": "uint8"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        },
-        "t_struct<Roles.Role>": {
-          "id": "t_struct<Roles.Role>",
-          "kind": "struct",
-          "label": "Roles.Role",
-          "members": [
-            {
-              "label": "bearer",
-              "astId": 1261,
-              "type": "t_mapping<t_bool>",
-              "src": "150:32:7"
-            }
-          ]
-        },
-        "t_mapping<t_bool>": {
-          "id": "t_mapping<t_bool>",
-          "valueType": "t_bool",
-          "label": "mapping(key => bool)",
-          "kind": "mapping"
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 3,
-          "type": "t_bool",
-          "src": "757:24:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 5,
-          "type": "t_bool",
-          "src": "876:25:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 61,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_name",
-          "astId": 11159,
-          "type": "t_string",
-          "src": "224:20:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_symbol",
-          "astId": 11161,
-          "type": "t_string",
-          "src": "250:22:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_decimals",
-          "astId": 11163,
-          "type": "t_uint8",
-          "src": "278:23:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "______gap",
-          "astId": 11215,
-          "type": "t_array:50<t_uint256>",
-          "src": "1654:29:131"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_balances",
-          "astId": 10639,
-          "type": "t_mapping<t_uint256>",
-          "src": "1418:46:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_allowances",
-          "astId": 10645,
-          "type": "t_mapping<t_uint256>",
-          "src": "1471:69:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_totalSupply",
-          "astId": 10647,
-          "type": "t_uint256",
-          "src": "1547:28:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "______gap",
-          "astId": 11031,
-          "type": "t_array:50<t_uint256>",
-          "src": "8173:29:128"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "_minters",
-          "astId": 1481,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:9"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "______gap",
-          "astId": 1581,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:9"
-        },
-        {
-          "contract": "ERC20Mintable",
-          "path": "contracts/token/ERC20/ERC20Mintable.sol",
-          "label": "______gap",
-          "astId": 11264,
-          "type": "t_array:50<t_uint256>",
-          "src": "831:29:132"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "_pausers",
-          "astId": 1604,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:10"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "______gap",
-          "astId": 1704,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:10"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "_paused",
-          "astId": 5582,
-          "type": "t_bool",
-          "src": "909:20:44"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "______gap",
-          "astId": 5665,
-          "type": "t_array:50<t_uint256>",
-          "src": "2163:29:44"
-        },
-        {
-          "contract": "ERC20Pausable",
-          "path": "contracts/token/ERC20/ERC20Pausable.sol",
-          "label": "______gap",
-          "astId": 11387,
-          "type": "t_array:50<t_uint256>",
-          "src": "1371:29:133"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
-      }
-    },
     "StandaloneERC721": {
-      "address": "0xBe11B1E14215442d728EB36b8Dd7ce3b2DDcB79f",
-      "constructorCode": "60806040525b5b61000b565b614a688061001a6000396000f3fe",
-      "bodyBytecodeHash": "4c4911b0db948d783dd8e71b2bc11b81c442c8959103e31484b62e71770008da",
-      "localBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
-      "deployedBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
+      "address": "0x7c8c90201ABfE56747Fb35776Bbf6004D5e2FC9d",
+      "constructorCode": "6080604052614852806100136000396000f3fe",
+      "bodyBytecodeHash": "88b94d215b26608378556f9b1eaa4c698e55d1f925c92ab2a1896edc517a4ace",
+      "localBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
+      "deployedBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -270,7 +48,7 @@
           "members": [
             {
               "label": "_value",
-              "astId": 3804,
+              "astId": 3810,
               "type": "t_uint256",
               "src": "1024:14:29"
             }
@@ -312,6 +90,13 @@
           "label": "mapping(key => string)",
           "kind": "mapping"
         },
+        "t_array:49<t_uint256>": {
+          "id": "t_array:49<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "49",
+          "kind": "array",
+          "label": "uint256[49]"
+        },
         "t_struct<Roles.Role>": {
           "id": "t_struct<Roles.Role>",
           "kind": "struct",
@@ -319,7 +104,7 @@
           "members": [
             {
               "label": "bearer",
-              "astId": 1261,
+              "astId": 1267,
               "type": "t_mapping<t_bool>",
               "src": "150:32:7"
             }
@@ -347,15 +132,15 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "ERC165",
           "path": "contracts/introspection/ERC165.sol",
           "label": "_supportedInterfaces",
-          "astId": 5215,
+          "astId": 5221,
           "type": "t_mapping<t_bool>",
           "src": "565:52:38"
         },
@@ -363,7 +148,7 @@
           "contract": "ERC165",
           "path": "contracts/introspection/ERC165.sol",
           "label": "______gap",
-          "astId": 5260,
+          "astId": 5266,
           "type": "t_array:50<t_uint256>",
           "src": "1729:29:38"
         },
@@ -371,119 +156,127 @@
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_tokenOwner",
-          "astId": 12030,
+          "astId": 12307,
           "type": "t_mapping<t_address>",
-          "src": "886:48:138"
+          "src": "886:48:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_tokenApprovals",
-          "astId": 12034,
+          "astId": 12311,
           "type": "t_mapping<t_address>",
-          "src": "990:52:138"
+          "src": "990:52:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_ownedTokensCount",
-          "astId": 12038,
+          "astId": 12315,
           "type": "t_mapping<t_struct<Counters.Counter>>",
-          "src": "1100:63:138"
+          "src": "1100:63:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_operatorApprovals",
-          "astId": 12044,
+          "astId": 12321,
           "type": "t_mapping<t_bool>",
-          "src": "1218:73:138"
+          "src": "1218:73:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "______gap",
-          "astId": 12656,
+          "astId": 12967,
           "type": "t_array:50<t_uint256>",
-          "src": "15262:29:138"
+          "src": "16014:29:141"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_ownedTokens",
-          "astId": 12714,
+          "astId": 13025,
           "type": "t_mapping<t_array:dyn<t_uint256>>",
-          "src": "502:50:140"
+          "src": "502:50:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_ownedTokensIndex",
-          "astId": 12718,
+          "astId": 13029,
           "type": "t_mapping<t_uint256>",
-          "src": "622:53:140"
+          "src": "622:53:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_allTokens",
-          "astId": 12721,
+          "astId": 13032,
           "type": "t_array:dyn<t_uint256>",
-          "src": "736:28:140"
+          "src": "736:28:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_allTokensIndex",
-          "astId": 12725,
+          "astId": 13036,
           "type": "t_mapping<t_uint256>",
-          "src": "835:51:140"
+          "src": "835:51:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "______gap",
-          "astId": 13056,
+          "astId": 13367,
           "type": "t_array:50<t_uint256>",
-          "src": "9053:29:140"
+          "src": "9053:29:143"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_name",
-          "astId": 13126,
+          "astId": 13437,
           "type": "t_string",
-          "src": "323:20:143"
+          "src": "323:20:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_symbol",
-          "astId": 13128,
+          "astId": 13439,
           "type": "t_string",
-          "src": "370:22:143"
+          "src": "370:22:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_tokenURIs",
-          "astId": 13132,
+          "astId": 13443,
           "type": "t_mapping<t_string>",
-          "src": "438:45:143"
+          "src": "438:45:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_baseURI",
+          "astId": 13445,
+          "type": "t_string",
+          "src": "506:23:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "______gap",
-          "astId": 13263,
-          "type": "t_array:50<t_uint256>",
-          "src": "3086:29:143"
+          "astId": 13615,
+          "type": "t_array:49<t_uint256>",
+          "src": "4297:29:146"
         },
         {
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "_minters",
-          "astId": 1481,
+          "astId": 1487,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:9"
         },
@@ -491,7 +284,7 @@
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "______gap",
-          "astId": 1581,
+          "astId": 1587,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:9"
         },
@@ -499,15 +292,15 @@
           "contract": "ERC721MetadataMintable",
           "path": "contracts/token/ERC721/ERC721MetadataMintable.sol",
           "label": "______gap",
-          "astId": 13333,
+          "astId": 13685,
           "type": "t_array:50<t_uint256>",
-          "src": "1057:29:144"
+          "src": "1057:29:147"
         },
         {
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "_pausers",
-          "astId": 1604,
+          "astId": 1610,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:10"
         },
@@ -515,7 +308,7 @@
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "______gap",
-          "astId": 1704,
+          "astId": 1710,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:10"
         },
@@ -523,7 +316,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "_paused",
-          "astId": 5582,
+          "astId": 5617,
           "type": "t_bool",
           "src": "909:20:44"
         },
@@ -531,7 +324,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "______gap",
-          "astId": 5665,
+          "astId": 5700,
           "type": "t_array:50<t_uint256>",
           "src": "2163:29:44"
         },
@@ -539,9 +332,9 @@
           "contract": "ERC721Pausable",
           "path": "contracts/token/ERC721/ERC721Pausable.sol",
           "label": "______gap",
-          "astId": 13519,
+          "astId": 13871,
           "type": "t_array:50<t_uint256>",
-          "src": "869:29:146"
+          "src": "869:29:149"
         }
       ],
       "warnings": {
@@ -549,15 +342,317 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "ERC721",
+            "path": "contracts/token/ERC721/ERC721.sol",
+            "label": "_ownedTokensCount",
+            "astId": 12315,
+            "type": "t_mapping<t_struct<Counters.Counter>>",
+            "src": "1100:63:141"
+          },
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": [
+          {
+            "action": "replace",
+            "updated": {
+              "index": 18,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "_baseURI",
+              "astId": 13445,
+              "type": "t_string",
+              "src": "506:23:146"
+            },
+            "original": {
+              "index": 18,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "______gap",
+              "astId": 13263,
+              "type": "t_array:50<t_uint256>",
+              "src": "3086:29:143"
+            }
+          },
+          {
+            "action": "insert",
+            "updated": {
+              "index": 19,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "______gap",
+              "astId": 13615,
+              "type": "t_array:49<t_uint256>",
+              "src": "4297:29:146"
+            }
+          }
+        ]
+      }
+    },
+    "StandaloneERC20": {
+      "address": "0x7Eefff0D65f49007aAAFa08a047f8A11B12f6944",
+      "constructorCode": "6080604052613351806100136000396000f3fe",
+      "bodyBytecodeHash": "5fece1bdf65e93391feb0bdf0c967cf306feb4e9cba3e43431d5974146bf0093",
+      "localBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "deployedBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_uint8": {
+          "id": "t_uint8",
+          "kind": "elementary",
+          "label": "uint8"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_struct<Roles.Role>": {
+          "id": "t_struct<Roles.Role>",
+          "kind": "struct",
+          "label": "Roles.Role",
+          "members": [
+            {
+              "label": "bearer",
+              "astId": 1267,
+              "type": "t_mapping<t_bool>",
+              "src": "150:32:7"
+            }
+          ]
+        },
+        "t_mapping<t_bool>": {
+          "id": "t_mapping<t_bool>",
+          "valueType": "t_bool",
+          "label": "mapping(key => bool)",
+          "kind": "mapping"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 3,
+          "type": "t_bool",
+          "src": "757:24:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5,
+          "type": "t_bool",
+          "src": "876:25:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 67,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:0"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_name",
+          "astId": 11436,
+          "type": "t_string",
+          "src": "224:20:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_symbol",
+          "astId": 11438,
+          "type": "t_string",
+          "src": "250:22:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_decimals",
+          "astId": 11440,
+          "type": "t_uint8",
+          "src": "278:23:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "______gap",
+          "astId": 11492,
+          "type": "t_array:50<t_uint256>",
+          "src": "1654:29:134"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_balances",
+          "astId": 10916,
+          "type": "t_mapping<t_uint256>",
+          "src": "1418:46:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_allowances",
+          "astId": 10922,
+          "type": "t_mapping<t_uint256>",
+          "src": "1471:69:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_totalSupply",
+          "astId": 10924,
+          "type": "t_uint256",
+          "src": "1547:28:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "______gap",
+          "astId": 11308,
+          "type": "t_array:50<t_uint256>",
+          "src": "8172:29:131"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "_minters",
+          "astId": 1487,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:9"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "______gap",
+          "astId": 1587,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:9"
+        },
+        {
+          "contract": "ERC20Mintable",
+          "path": "contracts/token/ERC20/ERC20Mintable.sol",
+          "label": "______gap",
+          "astId": 11541,
+          "type": "t_array:50<t_uint256>",
+          "src": "831:29:135"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "_pausers",
+          "astId": 1610,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:10"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "______gap",
+          "astId": 1710,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:10"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "_paused",
+          "astId": 5617,
+          "type": "t_bool",
+          "src": "909:20:44"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "______gap",
+          "astId": 5700,
+          "type": "t_array:50<t_uint256>",
+          "src": "2163:29:44"
+        },
+        {
+          "contract": "ERC20Pausable",
+          "path": "contracts/token/ERC20/ERC20Pausable.sol",
+          "label": "______gap",
+          "astId": 11664,
+          "type": "t_array:50<t_uint256>",
+          "src": "1371:29:136"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": []
       }
     },
     "TokenVesting": {
-      "address": "0x80Fe1041c782AfE6fBefC308947b60a546D0fC1D",
-      "constructorCode": "60806040525b5b61000b565b611f958061001a6000396000f3fe",
-      "bodyBytecodeHash": "bed509f74341ca413ee16f728b8d7ad30668fbbc9c01cc89eae2d42b7dd889b1",
-      "localBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
-      "deployedBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
+      "address": "0x2989a98BB3a178c7ef56BeB7453ffD69A636D499",
+      "constructorCode": "6080604052611de2806100136000396000f3fe",
+      "bodyBytecodeHash": "53b6c1230e5389805143264fff3365c615b5f0af3bb66a345f0c1537407097c4",
+      "localBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
+      "deployedBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -615,31 +710,31 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "Ownable",
           "path": "contracts/ownership/Ownable.sol",
           "label": "_owner",
-          "astId": 9652,
+          "astId": 9929,
           "type": "t_address",
-          "src": "526:22:121"
+          "src": "526:22:124"
         },
         {
           "contract": "Ownable",
           "path": "contracts/ownership/Ownable.sol",
           "label": "______gap",
-          "astId": 9765,
+          "astId": 10042,
           "type": "t_array:50<t_uint256>",
-          "src": "2471:29:121"
+          "src": "2471:29:124"
         },
         {
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_beneficiary",
-          "astId": 4676,
+          "astId": 4682,
           "type": "t_address",
           "src": "1148:28:35"
         },
@@ -647,7 +742,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_cliff",
-          "astId": 4678,
+          "astId": 4684,
           "type": "t_uint256",
           "src": "1278:22:35"
         },
@@ -655,7 +750,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_start",
-          "astId": 4680,
+          "astId": 4686,
           "type": "t_uint256",
           "src": "1306:22:35"
         },
@@ -663,7 +758,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_duration",
-          "astId": 4682,
+          "astId": 4688,
           "type": "t_uint256",
           "src": "1334:25:35"
         },
@@ -671,7 +766,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_revocable",
-          "astId": 4684,
+          "astId": 4690,
           "type": "t_bool",
           "src": "1366:23:35"
         },
@@ -679,7 +774,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_released",
-          "astId": 4688,
+          "astId": 4694,
           "type": "t_mapping<t_uint256>",
           "src": "1396:46:35"
         },
@@ -687,7 +782,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_revoked",
-          "astId": 4692,
+          "astId": 4698,
           "type": "t_mapping<t_bool>",
           "src": "1448:42:35"
         },
@@ -695,7 +790,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "______gap",
-          "astId": 5041,
+          "astId": 5047,
           "type": "t_array:50<t_uint256>",
           "src": "6241:29:35"
         }
@@ -705,15 +800,17 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [],
+        "storageDiff": []
       }
     },
     "PaymentSplitter": {
-      "address": "0x3dB52A5cd6606dA265bf03C9fD6946220b945c40",
-      "constructorCode": "60806040525b5b61000b565b6112f18061001a6000396000f3fe",
-      "bodyBytecodeHash": "35557e8a7b14e305cbe138016823233ea344a4366601f5dc7d81c92847e395dd",
-      "localBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
-      "deployedBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
+      "address": "0xD2B727697f831DC1b3e532C494E722d547a48341",
+      "constructorCode": "60806040526111d3806100136000396000f3fe",
+      "bodyBytecodeHash": "35fd934084a8702affa3466e8127098f9cdad9ae7aa9e2d49263951636d03111",
+      "localBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
+      "deployedBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -772,57 +869,57 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalShares",
-          "astId": 9878,
+          "astId": 10155,
           "type": "t_uint256",
-          "src": "1229:28:123"
+          "src": "1229:28:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalReleased",
-          "astId": 9880,
+          "astId": 10157,
           "type": "t_uint256",
-          "src": "1263:30:123"
+          "src": "1263:30:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_shares",
-          "astId": 9884,
+          "astId": 10161,
           "type": "t_mapping<t_uint256>",
-          "src": "1300:43:123"
+          "src": "1300:43:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_released",
-          "astId": 9888,
+          "astId": 10165,
           "type": "t_mapping<t_uint256>",
-          "src": "1349:45:123"
+          "src": "1349:45:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_payees",
-          "astId": 9891,
+          "astId": 10168,
           "type": "t_array:dyn<t_address>",
-          "src": "1400:25:123"
+          "src": "1400:25:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "______gap",
-          "astId": 10144,
+          "astId": 10421,
           "type": "t_array:50<t_uint256>",
-          "src": "5190:29:123"
+          "src": "5190:29:126"
         }
       ],
       "warnings": {
@@ -830,7 +927,9 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [],
+        "storageDiff": []
       }
     }
   },
@@ -845,7 +944,7 @@
     "address": "0xB6F8F11b166D526932ee04ffe4D25B810f619E34"
   },
   "provider": {
-    "address": "0x9658302F762E9eFE241378BF5E7C14904299Ea15"
+    "address": "0xBd8311c30718C766868C2ee95CAdc7532c757352"
   },
-  "version": "2.4.0"
+  "version": "2.5.0"
 }

--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1,11 +1,658 @@
 {
   "contracts": {
+    "StandaloneERC20": {
+      "address": "0xb8aAb8725D39FE0e02a1C3aEF801c71Dc64709cd",
+      "constructorCode": "6080604052613351806100136000396000f3fe",
+      "bodyBytecodeHash": "5fece1bdf65e93391feb0bdf0c967cf306feb4e9cba3e43431d5974146bf0093",
+      "localBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "deployedBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_uint8": {
+          "id": "t_uint8",
+          "kind": "elementary",
+          "label": "uint8"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_struct<Roles.Role>": {
+          "id": "t_struct<Roles.Role>",
+          "kind": "struct",
+          "label": "Roles.Role",
+          "members": [
+            {
+              "label": "bearer",
+              "astId": 1267,
+              "type": "t_mapping<t_bool>",
+              "src": "150:32:7"
+            }
+          ]
+        },
+        "t_mapping<t_bool>": {
+          "id": "t_mapping<t_bool>",
+          "valueType": "t_bool",
+          "label": "mapping(key => bool)",
+          "kind": "mapping"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 3,
+          "type": "t_bool",
+          "src": "757:24:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5,
+          "type": "t_bool",
+          "src": "876:25:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 67,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:0"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_name",
+          "astId": 11436,
+          "type": "t_string",
+          "src": "224:20:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_symbol",
+          "astId": 11438,
+          "type": "t_string",
+          "src": "250:22:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_decimals",
+          "astId": 11440,
+          "type": "t_uint8",
+          "src": "278:23:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "______gap",
+          "astId": 11492,
+          "type": "t_array:50<t_uint256>",
+          "src": "1654:29:134"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_balances",
+          "astId": 10916,
+          "type": "t_mapping<t_uint256>",
+          "src": "1418:46:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_allowances",
+          "astId": 10922,
+          "type": "t_mapping<t_uint256>",
+          "src": "1471:69:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_totalSupply",
+          "astId": 10924,
+          "type": "t_uint256",
+          "src": "1547:28:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "______gap",
+          "astId": 11308,
+          "type": "t_array:50<t_uint256>",
+          "src": "8172:29:131"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "_minters",
+          "astId": 1487,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:9"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "______gap",
+          "astId": 1587,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:9"
+        },
+        {
+          "contract": "ERC20Mintable",
+          "path": "contracts/token/ERC20/ERC20Mintable.sol",
+          "label": "______gap",
+          "astId": 11541,
+          "type": "t_array:50<t_uint256>",
+          "src": "831:29:135"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "_pausers",
+          "astId": 1610,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:10"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "______gap",
+          "astId": 1710,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:10"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "_paused",
+          "astId": 5617,
+          "type": "t_bool",
+          "src": "909:20:44"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "______gap",
+          "astId": 5700,
+          "type": "t_array:50<t_uint256>",
+          "src": "2163:29:44"
+        },
+        {
+          "contract": "ERC20Pausable",
+          "path": "contracts/token/ERC20/ERC20Pausable.sol",
+          "label": "______gap",
+          "astId": 11664,
+          "type": "t_array:50<t_uint256>",
+          "src": "1371:29:136"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": []
+      }
+    },
+    "StandaloneERC721": {
+      "address": "0xd699c87e346A8D62caf0E07fE9A31fDEeB47dea5",
+      "constructorCode": "6080604052614852806100136000396000f3fe",
+      "bodyBytecodeHash": "88b94d215b26608378556f9b1eaa4c698e55d1f925c92ab2a1896edc517a4ace",
+      "localBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
+      "deployedBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_mapping<t_bool>": {
+          "id": "t_mapping<t_bool>",
+          "valueType": "t_bool",
+          "label": "mapping(key => bool)",
+          "kind": "mapping"
+        },
+        "t_address": {
+          "id": "t_address",
+          "kind": "elementary",
+          "label": "address"
+        },
+        "t_mapping<t_address>": {
+          "id": "t_mapping<t_address>",
+          "valueType": "t_address",
+          "label": "mapping(key => address)",
+          "kind": "mapping"
+        },
+        "t_struct<Counters.Counter>": {
+          "id": "t_struct<Counters.Counter>",
+          "kind": "struct",
+          "label": "Counters.Counter",
+          "members": [
+            {
+              "label": "_value",
+              "astId": 3810,
+              "type": "t_uint256",
+              "src": "1024:14:29"
+            }
+          ]
+        },
+        "t_mapping<t_struct<Counters.Counter>>": {
+          "id": "t_mapping<t_struct<Counters.Counter>>",
+          "valueType": "t_struct<Counters.Counter>",
+          "label": "mapping(key => Counters.Counter)",
+          "kind": "mapping"
+        },
+        "t_array:dyn<t_uint256>": {
+          "id": "t_array:dyn<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "dyn",
+          "kind": "array",
+          "label": "uint256[]"
+        },
+        "t_mapping<t_array:dyn<t_uint256>>": {
+          "id": "t_mapping<t_array:dyn<t_uint256>>",
+          "valueType": "t_array:dyn<t_uint256>",
+          "label": "mapping(key => uint256[])",
+          "kind": "mapping"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_mapping<t_string>": {
+          "id": "t_mapping<t_string>",
+          "valueType": "t_string",
+          "label": "mapping(key => string)",
+          "kind": "mapping"
+        },
+        "t_array:49<t_uint256>": {
+          "id": "t_array:49<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "49",
+          "kind": "array",
+          "label": "uint256[49]"
+        },
+        "t_struct<Roles.Role>": {
+          "id": "t_struct<Roles.Role>",
+          "kind": "struct",
+          "label": "Roles.Role",
+          "members": [
+            {
+              "label": "bearer",
+              "astId": 1267,
+              "type": "t_mapping<t_bool>",
+              "src": "150:32:7"
+            }
+          ]
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 3,
+          "type": "t_bool",
+          "src": "757:24:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5,
+          "type": "t_bool",
+          "src": "876:25:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 67,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:0"
+        },
+        {
+          "contract": "ERC165",
+          "path": "contracts/introspection/ERC165.sol",
+          "label": "_supportedInterfaces",
+          "astId": 5221,
+          "type": "t_mapping<t_bool>",
+          "src": "565:52:38"
+        },
+        {
+          "contract": "ERC165",
+          "path": "contracts/introspection/ERC165.sol",
+          "label": "______gap",
+          "astId": 5266,
+          "type": "t_array:50<t_uint256>",
+          "src": "1729:29:38"
+        },
+        {
+          "contract": "ERC721",
+          "path": "contracts/token/ERC721/ERC721.sol",
+          "label": "_tokenOwner",
+          "astId": 12307,
+          "type": "t_mapping<t_address>",
+          "src": "886:48:141"
+        },
+        {
+          "contract": "ERC721",
+          "path": "contracts/token/ERC721/ERC721.sol",
+          "label": "_tokenApprovals",
+          "astId": 12311,
+          "type": "t_mapping<t_address>",
+          "src": "990:52:141"
+        },
+        {
+          "contract": "ERC721",
+          "path": "contracts/token/ERC721/ERC721.sol",
+          "label": "_ownedTokensCount",
+          "astId": 12315,
+          "type": "t_mapping<t_struct<Counters.Counter>>",
+          "src": "1100:63:141"
+        },
+        {
+          "contract": "ERC721",
+          "path": "contracts/token/ERC721/ERC721.sol",
+          "label": "_operatorApprovals",
+          "astId": 12321,
+          "type": "t_mapping<t_bool>",
+          "src": "1218:73:141"
+        },
+        {
+          "contract": "ERC721",
+          "path": "contracts/token/ERC721/ERC721.sol",
+          "label": "______gap",
+          "astId": 12967,
+          "type": "t_array:50<t_uint256>",
+          "src": "16014:29:141"
+        },
+        {
+          "contract": "ERC721Enumerable",
+          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
+          "label": "_ownedTokens",
+          "astId": 13025,
+          "type": "t_mapping<t_array:dyn<t_uint256>>",
+          "src": "502:50:143"
+        },
+        {
+          "contract": "ERC721Enumerable",
+          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
+          "label": "_ownedTokensIndex",
+          "astId": 13029,
+          "type": "t_mapping<t_uint256>",
+          "src": "622:53:143"
+        },
+        {
+          "contract": "ERC721Enumerable",
+          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
+          "label": "_allTokens",
+          "astId": 13032,
+          "type": "t_array:dyn<t_uint256>",
+          "src": "736:28:143"
+        },
+        {
+          "contract": "ERC721Enumerable",
+          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
+          "label": "_allTokensIndex",
+          "astId": 13036,
+          "type": "t_mapping<t_uint256>",
+          "src": "835:51:143"
+        },
+        {
+          "contract": "ERC721Enumerable",
+          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
+          "label": "______gap",
+          "astId": 13367,
+          "type": "t_array:50<t_uint256>",
+          "src": "9053:29:143"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_name",
+          "astId": 13437,
+          "type": "t_string",
+          "src": "323:20:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_symbol",
+          "astId": 13439,
+          "type": "t_string",
+          "src": "370:22:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_tokenURIs",
+          "astId": 13443,
+          "type": "t_mapping<t_string>",
+          "src": "438:45:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_baseURI",
+          "astId": 13445,
+          "type": "t_string",
+          "src": "506:23:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "______gap",
+          "astId": 13615,
+          "type": "t_array:49<t_uint256>",
+          "src": "4297:29:146"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "_minters",
+          "astId": 1487,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:9"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "______gap",
+          "astId": 1587,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:9"
+        },
+        {
+          "contract": "ERC721MetadataMintable",
+          "path": "contracts/token/ERC721/ERC721MetadataMintable.sol",
+          "label": "______gap",
+          "astId": 13685,
+          "type": "t_array:50<t_uint256>",
+          "src": "1057:29:147"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "_pausers",
+          "astId": 1610,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:10"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "______gap",
+          "astId": 1710,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:10"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "_paused",
+          "astId": 5617,
+          "type": "t_bool",
+          "src": "909:20:44"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "______gap",
+          "astId": 5700,
+          "type": "t_array:50<t_uint256>",
+          "src": "2163:29:44"
+        },
+        {
+          "contract": "ERC721Pausable",
+          "path": "contracts/token/ERC721/ERC721Pausable.sol",
+          "label": "______gap",
+          "astId": 13871,
+          "type": "t_array:50<t_uint256>",
+          "src": "869:29:149"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "ERC721",
+            "path": "contracts/token/ERC721/ERC721.sol",
+            "label": "_ownedTokensCount",
+            "astId": 12315,
+            "type": "t_mapping<t_struct<Counters.Counter>>",
+            "src": "1100:63:141"
+          },
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": [
+          {
+            "action": "replace",
+            "updated": {
+              "index": 18,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "_baseURI",
+              "astId": 13445,
+              "type": "t_string",
+              "src": "506:23:146"
+            },
+            "original": {
+              "index": 18,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "______gap",
+              "astId": 13263,
+              "type": "t_array:50<t_uint256>",
+              "src": "3086:29:143"
+            }
+          },
+          {
+            "action": "insert",
+            "updated": {
+              "index": 19,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "______gap",
+              "astId": 13615,
+              "type": "t_array:49<t_uint256>",
+              "src": "4297:29:146"
+            }
+          }
+        ]
+      }
+    },
     "PaymentSplitter": {
-      "address": "0x167985bFA2b2cf4Aa8560FB2170c5CE19289688a",
-      "constructorCode": "60806040525b5b61000b565b6112f18061001a6000396000f3fe",
-      "bodyBytecodeHash": "35557e8a7b14e305cbe138016823233ea344a4366601f5dc7d81c92847e395dd",
-      "localBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
-      "deployedBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
+      "address": "0x438F22Bb6851a130D04626C9A0006aC12478308d",
+      "constructorCode": "60806040526111d3806100136000396000f3fe",
+      "bodyBytecodeHash": "35fd934084a8702affa3466e8127098f9cdad9ae7aa9e2d49263951636d03111",
+      "localBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
+      "deployedBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -64,57 +711,57 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalShares",
-          "astId": 9878,
+          "astId": 10155,
           "type": "t_uint256",
-          "src": "1229:28:123"
+          "src": "1229:28:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalReleased",
-          "astId": 9880,
+          "astId": 10157,
           "type": "t_uint256",
-          "src": "1263:30:123"
+          "src": "1263:30:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_shares",
-          "astId": 9884,
+          "astId": 10161,
           "type": "t_mapping<t_uint256>",
-          "src": "1300:43:123"
+          "src": "1300:43:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_released",
-          "astId": 9888,
+          "astId": 10165,
           "type": "t_mapping<t_uint256>",
-          "src": "1349:45:123"
+          "src": "1349:45:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_payees",
-          "astId": 9891,
+          "astId": 10168,
           "type": "t_array:dyn<t_address>",
-          "src": "1400:25:123"
+          "src": "1400:25:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "______gap",
-          "astId": 10144,
+          "astId": 10421,
           "type": "t_array:50<t_uint256>",
-          "src": "5190:29:123"
+          "src": "5190:29:126"
         }
       ],
       "warnings": {
@@ -127,610 +774,12 @@
         "storageDiff": []
       }
     },
-    "StandaloneERC20": {
-      "address": "0x9543977d87b9D7340FDBA32B3cbc5C31e672a7c8",
-      "constructorCode": "60806040525b5b61000b565b61372e8061001a6000396000f3fe",
-      "bodyBytecodeHash": "e85eba9d1581c280b848dcd3b157b8b519012a715adc705ed19e0e3b2d1331fe",
-      "localBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "deployedBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_string": {
-          "id": "t_string",
-          "kind": "elementary",
-          "label": "string"
-        },
-        "t_uint8": {
-          "id": "t_uint8",
-          "kind": "elementary",
-          "label": "uint8"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        },
-        "t_struct<Roles.Role>": {
-          "id": "t_struct<Roles.Role>",
-          "kind": "struct",
-          "label": "Roles.Role",
-          "members": [
-            {
-              "label": "bearer",
-              "astId": 1261,
-              "type": "t_mapping<t_bool>",
-              "src": "150:32:7"
-            }
-          ]
-        },
-        "t_mapping<t_bool>": {
-          "id": "t_mapping<t_bool>",
-          "valueType": "t_bool",
-          "label": "mapping(key => bool)",
-          "kind": "mapping"
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 3,
-          "type": "t_bool",
-          "src": "757:24:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 5,
-          "type": "t_bool",
-          "src": "876:25:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 61,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_name",
-          "astId": 11159,
-          "type": "t_string",
-          "src": "224:20:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_symbol",
-          "astId": 11161,
-          "type": "t_string",
-          "src": "250:22:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_decimals",
-          "astId": 11163,
-          "type": "t_uint8",
-          "src": "278:23:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "______gap",
-          "astId": 11215,
-          "type": "t_array:50<t_uint256>",
-          "src": "1654:29:131"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_balances",
-          "astId": 10639,
-          "type": "t_mapping<t_uint256>",
-          "src": "1418:46:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_allowances",
-          "astId": 10645,
-          "type": "t_mapping<t_uint256>",
-          "src": "1471:69:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_totalSupply",
-          "astId": 10647,
-          "type": "t_uint256",
-          "src": "1547:28:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "______gap",
-          "astId": 11031,
-          "type": "t_array:50<t_uint256>",
-          "src": "8173:29:128"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "_minters",
-          "astId": 1481,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:9"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "______gap",
-          "astId": 1581,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:9"
-        },
-        {
-          "contract": "ERC20Mintable",
-          "path": "contracts/token/ERC20/ERC20Mintable.sol",
-          "label": "______gap",
-          "astId": 11264,
-          "type": "t_array:50<t_uint256>",
-          "src": "831:29:132"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "_pausers",
-          "astId": 1604,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:10"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "______gap",
-          "astId": 1704,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:10"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "_paused",
-          "astId": 5582,
-          "type": "t_bool",
-          "src": "909:20:44"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "______gap",
-          "astId": 5665,
-          "type": "t_array:50<t_uint256>",
-          "src": "2163:29:44"
-        },
-        {
-          "contract": "ERC20Pausable",
-          "path": "contracts/token/ERC20/ERC20Pausable.sol",
-          "label": "______gap",
-          "astId": 11387,
-          "type": "t_array:50<t_uint256>",
-          "src": "1371:29:133"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [
-          {
-            "contract": "MinterRole",
-            "path": "contracts/access/roles/MinterRole.sol",
-            "label": "_minters",
-            "astId": 1481,
-            "type": "t_struct<Roles.Role>",
-            "src": "327:27:9"
-          },
-          {
-            "contract": "PauserRole",
-            "path": "contracts/access/roles/PauserRole.sol",
-            "label": "_pausers",
-            "astId": 1604,
-            "type": "t_struct<Roles.Role>",
-            "src": "327:27:10"
-          }
-        ],
-        "storageDiff": []
-      }
-    },
-    "StandaloneERC721": {
-      "address": "0x0528D990c91eDFbC5Ec5284AaceA9448912942d9",
-      "constructorCode": "60806040525b5b61000b565b614a688061001a6000396000f3fe",
-      "bodyBytecodeHash": "4c4911b0db948d783dd8e71b2bc11b81c442c8959103e31484b62e71770008da",
-      "localBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
-      "deployedBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_mapping<t_bool>": {
-          "id": "t_mapping<t_bool>",
-          "valueType": "t_bool",
-          "label": "mapping(key => bool)",
-          "kind": "mapping"
-        },
-        "t_address": {
-          "id": "t_address",
-          "kind": "elementary",
-          "label": "address"
-        },
-        "t_mapping<t_address>": {
-          "id": "t_mapping<t_address>",
-          "valueType": "t_address",
-          "label": "mapping(key => address)",
-          "kind": "mapping"
-        },
-        "t_struct<Counters.Counter>": {
-          "id": "t_struct<Counters.Counter>",
-          "kind": "struct",
-          "label": "Counters.Counter",
-          "members": [
-            {
-              "label": "_value",
-              "astId": 3804,
-              "type": "t_uint256",
-              "src": "1024:14:29"
-            }
-          ]
-        },
-        "t_mapping<t_struct<Counters.Counter>>": {
-          "id": "t_mapping<t_struct<Counters.Counter>>",
-          "valueType": "t_struct<Counters.Counter>",
-          "label": "mapping(key => Counters.Counter)",
-          "kind": "mapping"
-        },
-        "t_array:dyn<t_uint256>": {
-          "id": "t_array:dyn<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "dyn",
-          "kind": "array",
-          "label": "uint256[]"
-        },
-        "t_mapping<t_array:dyn<t_uint256>>": {
-          "id": "t_mapping<t_array:dyn<t_uint256>>",
-          "valueType": "t_array:dyn<t_uint256>",
-          "label": "mapping(key => uint256[])",
-          "kind": "mapping"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        },
-        "t_string": {
-          "id": "t_string",
-          "kind": "elementary",
-          "label": "string"
-        },
-        "t_mapping<t_string>": {
-          "id": "t_mapping<t_string>",
-          "valueType": "t_string",
-          "label": "mapping(key => string)",
-          "kind": "mapping"
-        },
-        "t_struct<Roles.Role>": {
-          "id": "t_struct<Roles.Role>",
-          "kind": "struct",
-          "label": "Roles.Role",
-          "members": [
-            {
-              "label": "bearer",
-              "astId": 1261,
-              "type": "t_mapping<t_bool>",
-              "src": "150:32:7"
-            }
-          ]
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 3,
-          "type": "t_bool",
-          "src": "757:24:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 5,
-          "type": "t_bool",
-          "src": "876:25:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 61,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
-        },
-        {
-          "contract": "ERC165",
-          "path": "contracts/introspection/ERC165.sol",
-          "label": "_supportedInterfaces",
-          "astId": 5215,
-          "type": "t_mapping<t_bool>",
-          "src": "565:52:38"
-        },
-        {
-          "contract": "ERC165",
-          "path": "contracts/introspection/ERC165.sol",
-          "label": "______gap",
-          "astId": 5260,
-          "type": "t_array:50<t_uint256>",
-          "src": "1729:29:38"
-        },
-        {
-          "contract": "ERC721",
-          "path": "contracts/token/ERC721/ERC721.sol",
-          "label": "_tokenOwner",
-          "astId": 12030,
-          "type": "t_mapping<t_address>",
-          "src": "886:48:138"
-        },
-        {
-          "contract": "ERC721",
-          "path": "contracts/token/ERC721/ERC721.sol",
-          "label": "_tokenApprovals",
-          "astId": 12034,
-          "type": "t_mapping<t_address>",
-          "src": "990:52:138"
-        },
-        {
-          "contract": "ERC721",
-          "path": "contracts/token/ERC721/ERC721.sol",
-          "label": "_ownedTokensCount",
-          "astId": 12038,
-          "type": "t_mapping<t_struct<Counters.Counter>>",
-          "src": "1100:63:138"
-        },
-        {
-          "contract": "ERC721",
-          "path": "contracts/token/ERC721/ERC721.sol",
-          "label": "_operatorApprovals",
-          "astId": 12044,
-          "type": "t_mapping<t_bool>",
-          "src": "1218:73:138"
-        },
-        {
-          "contract": "ERC721",
-          "path": "contracts/token/ERC721/ERC721.sol",
-          "label": "______gap",
-          "astId": 12656,
-          "type": "t_array:50<t_uint256>",
-          "src": "15262:29:138"
-        },
-        {
-          "contract": "ERC721Enumerable",
-          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
-          "label": "_ownedTokens",
-          "astId": 12714,
-          "type": "t_mapping<t_array:dyn<t_uint256>>",
-          "src": "502:50:140"
-        },
-        {
-          "contract": "ERC721Enumerable",
-          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
-          "label": "_ownedTokensIndex",
-          "astId": 12718,
-          "type": "t_mapping<t_uint256>",
-          "src": "622:53:140"
-        },
-        {
-          "contract": "ERC721Enumerable",
-          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
-          "label": "_allTokens",
-          "astId": 12721,
-          "type": "t_array:dyn<t_uint256>",
-          "src": "736:28:140"
-        },
-        {
-          "contract": "ERC721Enumerable",
-          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
-          "label": "_allTokensIndex",
-          "astId": 12725,
-          "type": "t_mapping<t_uint256>",
-          "src": "835:51:140"
-        },
-        {
-          "contract": "ERC721Enumerable",
-          "path": "contracts/token/ERC721/ERC721Enumerable.sol",
-          "label": "______gap",
-          "astId": 13056,
-          "type": "t_array:50<t_uint256>",
-          "src": "9053:29:140"
-        },
-        {
-          "contract": "ERC721Metadata",
-          "path": "contracts/token/ERC721/ERC721Metadata.sol",
-          "label": "_name",
-          "astId": 13126,
-          "type": "t_string",
-          "src": "323:20:143"
-        },
-        {
-          "contract": "ERC721Metadata",
-          "path": "contracts/token/ERC721/ERC721Metadata.sol",
-          "label": "_symbol",
-          "astId": 13128,
-          "type": "t_string",
-          "src": "370:22:143"
-        },
-        {
-          "contract": "ERC721Metadata",
-          "path": "contracts/token/ERC721/ERC721Metadata.sol",
-          "label": "_tokenURIs",
-          "astId": 13132,
-          "type": "t_mapping<t_string>",
-          "src": "438:45:143"
-        },
-        {
-          "contract": "ERC721Metadata",
-          "path": "contracts/token/ERC721/ERC721Metadata.sol",
-          "label": "______gap",
-          "astId": 13263,
-          "type": "t_array:50<t_uint256>",
-          "src": "3086:29:143"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "_minters",
-          "astId": 1481,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:9"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "______gap",
-          "astId": 1581,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:9"
-        },
-        {
-          "contract": "ERC721MetadataMintable",
-          "path": "contracts/token/ERC721/ERC721MetadataMintable.sol",
-          "label": "______gap",
-          "astId": 13333,
-          "type": "t_array:50<t_uint256>",
-          "src": "1057:29:144"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "_pausers",
-          "astId": 1604,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:10"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "______gap",
-          "astId": 1704,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:10"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "_paused",
-          "astId": 5582,
-          "type": "t_bool",
-          "src": "909:20:44"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "______gap",
-          "astId": 5665,
-          "type": "t_array:50<t_uint256>",
-          "src": "2163:29:44"
-        },
-        {
-          "contract": "ERC721Pausable",
-          "path": "contracts/token/ERC721/ERC721Pausable.sol",
-          "label": "______gap",
-          "astId": 13519,
-          "type": "t_array:50<t_uint256>",
-          "src": "869:29:146"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": [],
-        "storageUncheckedVars": [
-          {
-            "contract": "ERC721",
-            "path": "contracts/token/ERC721/ERC721.sol",
-            "label": "_ownedTokensCount",
-            "astId": 12038,
-            "type": "t_mapping<t_struct<Counters.Counter>>",
-            "src": "1100:63:138"
-          },
-          {
-            "contract": "MinterRole",
-            "path": "contracts/access/roles/MinterRole.sol",
-            "label": "_minters",
-            "astId": 1481,
-            "type": "t_struct<Roles.Role>",
-            "src": "327:27:9"
-          },
-          {
-            "contract": "PauserRole",
-            "path": "contracts/access/roles/PauserRole.sol",
-            "label": "_pausers",
-            "astId": 1604,
-            "type": "t_struct<Roles.Role>",
-            "src": "327:27:10"
-          }
-        ],
-        "storageDiff": []
-      }
-    },
     "TokenVesting": {
-      "address": "0xc0d3a5c42E0B20Dbf005519a0A93a75Ba105d425",
-      "constructorCode": "60806040525b5b61000b565b611f958061001a6000396000f3fe",
-      "bodyBytecodeHash": "bed509f74341ca413ee16f728b8d7ad30668fbbc9c01cc89eae2d42b7dd889b1",
-      "localBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
-      "deployedBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
+      "address": "0x3da10261320EF50A680D2973b212A060b9EC2DEF",
+      "constructorCode": "6080604052611de2806100136000396000f3fe",
+      "bodyBytecodeHash": "53b6c1230e5389805143264fff3365c615b5f0af3bb66a345f0c1537407097c4",
+      "localBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
+      "deployedBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -788,31 +837,31 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "Ownable",
           "path": "contracts/ownership/Ownable.sol",
           "label": "_owner",
-          "astId": 9652,
+          "astId": 9929,
           "type": "t_address",
-          "src": "526:22:121"
+          "src": "526:22:124"
         },
         {
           "contract": "Ownable",
           "path": "contracts/ownership/Ownable.sol",
           "label": "______gap",
-          "astId": 9765,
+          "astId": 10042,
           "type": "t_array:50<t_uint256>",
-          "src": "2471:29:121"
+          "src": "2471:29:124"
         },
         {
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_beneficiary",
-          "astId": 4676,
+          "astId": 4682,
           "type": "t_address",
           "src": "1148:28:35"
         },
@@ -820,7 +869,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_cliff",
-          "astId": 4678,
+          "astId": 4684,
           "type": "t_uint256",
           "src": "1278:22:35"
         },
@@ -828,7 +877,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_start",
-          "astId": 4680,
+          "astId": 4686,
           "type": "t_uint256",
           "src": "1306:22:35"
         },
@@ -836,7 +885,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_duration",
-          "astId": 4682,
+          "astId": 4688,
           "type": "t_uint256",
           "src": "1334:25:35"
         },
@@ -844,7 +893,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_revocable",
-          "astId": 4684,
+          "astId": 4690,
           "type": "t_bool",
           "src": "1366:23:35"
         },
@@ -852,7 +901,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_released",
-          "astId": 4688,
+          "astId": 4694,
           "type": "t_mapping<t_uint256>",
           "src": "1396:46:35"
         },
@@ -860,7 +909,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_revoked",
-          "astId": 4692,
+          "astId": 4698,
           "type": "t_mapping<t_bool>",
           "src": "1448:42:35"
         },
@@ -868,7 +917,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "______gap",
-          "astId": 5041,
+          "astId": 5047,
           "type": "t_array:50<t_uint256>",
           "src": "6241:29:35"
         }
@@ -895,7 +944,7 @@
     "address": "0x778dddF23Ec1B5Cb18394c6C110480CaaDB3B0f6"
   },
   "provider": {
-    "address": "0xfF2dBa38eD377918833Be8689f5588Dd61d3e7ea"
+    "address": "0x7b3A1Ba81e6E92C69277B1D5D96d76f49e75E74D"
   },
-  "version": "2.4.0"
+  "version": "2.5.0"
 }

--- a/.openzeppelin/project.json
+++ b/.openzeppelin/project.json
@@ -2,7 +2,7 @@
   "manifestVersion": "2.2",
   "name": "@openzeppelin/contracts-ethereum-package",
   "publish": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "contracts": {
     "StandaloneERC20": "StandaloneERC20",
     "StandaloneERC721": "StandaloneERC721",

--- a/.openzeppelin/rinkeby.json
+++ b/.openzeppelin/rinkeby.json
@@ -1,11 +1,11 @@
 {
   "contracts": {
     "TokenVesting": {
-      "address": "0x7fc59EEC7bb8f1257Cd315Ccf0d1181AeAb9084b",
-      "constructorCode": "60806040525b5b61000b565b611f958061001a6000396000f3fe",
-      "bodyBytecodeHash": "bed509f74341ca413ee16f728b8d7ad30668fbbc9c01cc89eae2d42b7dd889b1",
-      "localBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
-      "deployedBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
+      "address": "0x84310599d70abA22B9ea4D7D353fd30a10505F95",
+      "constructorCode": "6080604052611de2806100136000396000f3fe",
+      "bodyBytecodeHash": "53b6c1230e5389805143264fff3365c615b5f0af3bb66a345f0c1537407097c4",
+      "localBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
+      "deployedBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -63,31 +63,31 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "Ownable",
           "path": "contracts/ownership/Ownable.sol",
           "label": "_owner",
-          "astId": 9652,
+          "astId": 9929,
           "type": "t_address",
-          "src": "526:22:121"
+          "src": "526:22:124"
         },
         {
           "contract": "Ownable",
           "path": "contracts/ownership/Ownable.sol",
           "label": "______gap",
-          "astId": 9765,
+          "astId": 10042,
           "type": "t_array:50<t_uint256>",
-          "src": "2471:29:121"
+          "src": "2471:29:124"
         },
         {
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_beneficiary",
-          "astId": 4676,
+          "astId": 4682,
           "type": "t_address",
           "src": "1148:28:35"
         },
@@ -95,7 +95,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_cliff",
-          "astId": 4678,
+          "astId": 4684,
           "type": "t_uint256",
           "src": "1278:22:35"
         },
@@ -103,7 +103,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_start",
-          "astId": 4680,
+          "astId": 4686,
           "type": "t_uint256",
           "src": "1306:22:35"
         },
@@ -111,7 +111,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_duration",
-          "astId": 4682,
+          "astId": 4688,
           "type": "t_uint256",
           "src": "1334:25:35"
         },
@@ -119,7 +119,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_revocable",
-          "astId": 4684,
+          "astId": 4690,
           "type": "t_bool",
           "src": "1366:23:35"
         },
@@ -127,7 +127,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_released",
-          "astId": 4688,
+          "astId": 4694,
           "type": "t_mapping<t_uint256>",
           "src": "1396:46:35"
         },
@@ -135,7 +135,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "_revoked",
-          "astId": 4692,
+          "astId": 4698,
           "type": "t_mapping<t_bool>",
           "src": "1448:42:35"
         },
@@ -143,7 +143,7 @@
           "contract": "TokenVesting",
           "path": "contracts/drafts/TokenVesting.sol",
           "label": "______gap",
-          "astId": 5041,
+          "astId": 5047,
           "type": "t_array:50<t_uint256>",
           "src": "6241:29:35"
         }
@@ -153,15 +153,17 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [],
+        "storageDiff": []
       }
     },
     "StandaloneERC20": {
-      "address": "0x2b78620F63156a39eCaE0C47BAd772B6982768D6",
-      "constructorCode": "60806040525b5b61000b565b61372e8061001a6000396000f3fe",
-      "bodyBytecodeHash": "e85eba9d1581c280b848dcd3b157b8b519012a715adc705ed19e0e3b2d1331fe",
-      "localBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "deployedBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
+      "address": "0xD77960f7c0f2DC012e077BA10fB4747f9FEeEB86",
+      "constructorCode": "6080604052613351806100136000396000f3fe",
+      "bodyBytecodeHash": "5fece1bdf65e93391feb0bdf0c967cf306feb4e9cba3e43431d5974146bf0093",
+      "localBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "deployedBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -203,7 +205,7 @@
           "members": [
             {
               "label": "bearer",
-              "astId": 1261,
+              "astId": 1267,
               "type": "t_mapping<t_bool>",
               "src": "150:32:7"
             }
@@ -237,79 +239,79 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "ERC20Detailed",
           "path": "contracts/token/ERC20/ERC20Detailed.sol",
           "label": "_name",
-          "astId": 11159,
+          "astId": 11436,
           "type": "t_string",
-          "src": "224:20:131"
+          "src": "224:20:134"
         },
         {
           "contract": "ERC20Detailed",
           "path": "contracts/token/ERC20/ERC20Detailed.sol",
           "label": "_symbol",
-          "astId": 11161,
+          "astId": 11438,
           "type": "t_string",
-          "src": "250:22:131"
+          "src": "250:22:134"
         },
         {
           "contract": "ERC20Detailed",
           "path": "contracts/token/ERC20/ERC20Detailed.sol",
           "label": "_decimals",
-          "astId": 11163,
+          "astId": 11440,
           "type": "t_uint8",
-          "src": "278:23:131"
+          "src": "278:23:134"
         },
         {
           "contract": "ERC20Detailed",
           "path": "contracts/token/ERC20/ERC20Detailed.sol",
           "label": "______gap",
-          "astId": 11215,
+          "astId": 11492,
           "type": "t_array:50<t_uint256>",
-          "src": "1654:29:131"
+          "src": "1654:29:134"
         },
         {
           "contract": "ERC20",
           "path": "contracts/token/ERC20/ERC20.sol",
           "label": "_balances",
-          "astId": 10639,
+          "astId": 10916,
           "type": "t_mapping<t_uint256>",
-          "src": "1418:46:128"
+          "src": "1418:46:131"
         },
         {
           "contract": "ERC20",
           "path": "contracts/token/ERC20/ERC20.sol",
           "label": "_allowances",
-          "astId": 10645,
+          "astId": 10922,
           "type": "t_mapping<t_uint256>",
-          "src": "1471:69:128"
+          "src": "1471:69:131"
         },
         {
           "contract": "ERC20",
           "path": "contracts/token/ERC20/ERC20.sol",
           "label": "_totalSupply",
-          "astId": 10647,
+          "astId": 10924,
           "type": "t_uint256",
-          "src": "1547:28:128"
+          "src": "1547:28:131"
         },
         {
           "contract": "ERC20",
           "path": "contracts/token/ERC20/ERC20.sol",
           "label": "______gap",
-          "astId": 11031,
+          "astId": 11308,
           "type": "t_array:50<t_uint256>",
-          "src": "8173:29:128"
+          "src": "8172:29:131"
         },
         {
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "_minters",
-          "astId": 1481,
+          "astId": 1487,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:9"
         },
@@ -317,7 +319,7 @@
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "______gap",
-          "astId": 1581,
+          "astId": 1587,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:9"
         },
@@ -325,15 +327,15 @@
           "contract": "ERC20Mintable",
           "path": "contracts/token/ERC20/ERC20Mintable.sol",
           "label": "______gap",
-          "astId": 11264,
+          "astId": 11541,
           "type": "t_array:50<t_uint256>",
-          "src": "831:29:132"
+          "src": "831:29:135"
         },
         {
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "_pausers",
-          "astId": 1604,
+          "astId": 1610,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:10"
         },
@@ -341,7 +343,7 @@
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "______gap",
-          "astId": 1704,
+          "astId": 1710,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:10"
         },
@@ -349,7 +351,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "_paused",
-          "astId": 5582,
+          "astId": 5617,
           "type": "t_bool",
           "src": "909:20:44"
         },
@@ -357,7 +359,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "______gap",
-          "astId": 5665,
+          "astId": 5700,
           "type": "t_array:50<t_uint256>",
           "src": "2163:29:44"
         },
@@ -365,9 +367,9 @@
           "contract": "ERC20Pausable",
           "path": "contracts/token/ERC20/ERC20Pausable.sol",
           "label": "______gap",
-          "astId": 11387,
+          "astId": 11664,
           "type": "t_array:50<t_uint256>",
-          "src": "1371:29:133"
+          "src": "1371:29:136"
         }
       ],
       "warnings": {
@@ -375,15 +377,34 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": []
       }
     },
     "PaymentSplitter": {
-      "address": "0x2A7998D4771d2172DdB390B9F964a51Da8b8de63",
-      "constructorCode": "60806040525b5b61000b565b6112f18061001a6000396000f3fe",
-      "bodyBytecodeHash": "35557e8a7b14e305cbe138016823233ea344a4366601f5dc7d81c92847e395dd",
-      "localBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
-      "deployedBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
+      "address": "0xF56Ce8EBa019927314ada6456d517389aCDe9840",
+      "constructorCode": "60806040526111d3806100136000396000f3fe",
+      "bodyBytecodeHash": "35fd934084a8702affa3466e8127098f9cdad9ae7aa9e2d49263951636d03111",
+      "localBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
+      "deployedBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -442,57 +463,57 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalShares",
-          "astId": 9878,
+          "astId": 10155,
           "type": "t_uint256",
-          "src": "1229:28:123"
+          "src": "1229:28:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalReleased",
-          "astId": 9880,
+          "astId": 10157,
           "type": "t_uint256",
-          "src": "1263:30:123"
+          "src": "1263:30:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_shares",
-          "astId": 9884,
+          "astId": 10161,
           "type": "t_mapping<t_uint256>",
-          "src": "1300:43:123"
+          "src": "1300:43:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_released",
-          "astId": 9888,
+          "astId": 10165,
           "type": "t_mapping<t_uint256>",
-          "src": "1349:45:123"
+          "src": "1349:45:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_payees",
-          "astId": 9891,
+          "astId": 10168,
           "type": "t_array:dyn<t_address>",
-          "src": "1400:25:123"
+          "src": "1400:25:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "______gap",
-          "astId": 10144,
+          "astId": 10421,
           "type": "t_array:50<t_uint256>",
-          "src": "5190:29:123"
+          "src": "5190:29:126"
         }
       ],
       "warnings": {
@@ -500,15 +521,17 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [],
+        "storageDiff": []
       }
     },
     "StandaloneERC721": {
-      "address": "0xA15a4fe94a2614E11F8c4eDc46949ED4CFa6c2D6",
-      "constructorCode": "60806040525b5b61000b565b614a688061001a6000396000f3fe",
-      "bodyBytecodeHash": "4c4911b0db948d783dd8e71b2bc11b81c442c8959103e31484b62e71770008da",
-      "localBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
-      "deployedBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
+      "address": "0x91DCF78194c3D72ed22298927cF80a6e2F4e8795",
+      "constructorCode": "6080604052614852806100136000396000f3fe",
+      "bodyBytecodeHash": "88b94d215b26608378556f9b1eaa4c698e55d1f925c92ab2a1896edc517a4ace",
+      "localBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
+      "deployedBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -551,7 +574,7 @@
           "members": [
             {
               "label": "_value",
-              "astId": 3804,
+              "astId": 3810,
               "type": "t_uint256",
               "src": "1024:14:29"
             }
@@ -593,6 +616,13 @@
           "label": "mapping(key => string)",
           "kind": "mapping"
         },
+        "t_array:49<t_uint256>": {
+          "id": "t_array:49<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "49",
+          "kind": "array",
+          "label": "uint256[49]"
+        },
         "t_struct<Roles.Role>": {
           "id": "t_struct<Roles.Role>",
           "kind": "struct",
@@ -600,7 +630,7 @@
           "members": [
             {
               "label": "bearer",
-              "astId": 1261,
+              "astId": 1267,
               "type": "t_mapping<t_bool>",
               "src": "150:32:7"
             }
@@ -628,15 +658,15 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "ERC165",
           "path": "contracts/introspection/ERC165.sol",
           "label": "_supportedInterfaces",
-          "astId": 5215,
+          "astId": 5221,
           "type": "t_mapping<t_bool>",
           "src": "565:52:38"
         },
@@ -644,7 +674,7 @@
           "contract": "ERC165",
           "path": "contracts/introspection/ERC165.sol",
           "label": "______gap",
-          "astId": 5260,
+          "astId": 5266,
           "type": "t_array:50<t_uint256>",
           "src": "1729:29:38"
         },
@@ -652,119 +682,127 @@
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_tokenOwner",
-          "astId": 12030,
+          "astId": 12307,
           "type": "t_mapping<t_address>",
-          "src": "886:48:138"
+          "src": "886:48:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_tokenApprovals",
-          "astId": 12034,
+          "astId": 12311,
           "type": "t_mapping<t_address>",
-          "src": "990:52:138"
+          "src": "990:52:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_ownedTokensCount",
-          "astId": 12038,
+          "astId": 12315,
           "type": "t_mapping<t_struct<Counters.Counter>>",
-          "src": "1100:63:138"
+          "src": "1100:63:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_operatorApprovals",
-          "astId": 12044,
+          "astId": 12321,
           "type": "t_mapping<t_bool>",
-          "src": "1218:73:138"
+          "src": "1218:73:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "______gap",
-          "astId": 12656,
+          "astId": 12967,
           "type": "t_array:50<t_uint256>",
-          "src": "15262:29:138"
+          "src": "16014:29:141"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_ownedTokens",
-          "astId": 12714,
+          "astId": 13025,
           "type": "t_mapping<t_array:dyn<t_uint256>>",
-          "src": "502:50:140"
+          "src": "502:50:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_ownedTokensIndex",
-          "astId": 12718,
+          "astId": 13029,
           "type": "t_mapping<t_uint256>",
-          "src": "622:53:140"
+          "src": "622:53:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_allTokens",
-          "astId": 12721,
+          "astId": 13032,
           "type": "t_array:dyn<t_uint256>",
-          "src": "736:28:140"
+          "src": "736:28:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_allTokensIndex",
-          "astId": 12725,
+          "astId": 13036,
           "type": "t_mapping<t_uint256>",
-          "src": "835:51:140"
+          "src": "835:51:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "______gap",
-          "astId": 13056,
+          "astId": 13367,
           "type": "t_array:50<t_uint256>",
-          "src": "9053:29:140"
+          "src": "9053:29:143"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_name",
-          "astId": 13126,
+          "astId": 13437,
           "type": "t_string",
-          "src": "323:20:143"
+          "src": "323:20:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_symbol",
-          "astId": 13128,
+          "astId": 13439,
           "type": "t_string",
-          "src": "370:22:143"
+          "src": "370:22:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_tokenURIs",
-          "astId": 13132,
+          "astId": 13443,
           "type": "t_mapping<t_string>",
-          "src": "438:45:143"
+          "src": "438:45:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_baseURI",
+          "astId": 13445,
+          "type": "t_string",
+          "src": "506:23:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "______gap",
-          "astId": 13263,
-          "type": "t_array:50<t_uint256>",
-          "src": "3086:29:143"
+          "astId": 13615,
+          "type": "t_array:49<t_uint256>",
+          "src": "4297:29:146"
         },
         {
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "_minters",
-          "astId": 1481,
+          "astId": 1487,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:9"
         },
@@ -772,7 +810,7 @@
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "______gap",
-          "astId": 1581,
+          "astId": 1587,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:9"
         },
@@ -780,15 +818,15 @@
           "contract": "ERC721MetadataMintable",
           "path": "contracts/token/ERC721/ERC721MetadataMintable.sol",
           "label": "______gap",
-          "astId": 13333,
+          "astId": 13685,
           "type": "t_array:50<t_uint256>",
-          "src": "1057:29:144"
+          "src": "1057:29:147"
         },
         {
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "_pausers",
-          "astId": 1604,
+          "astId": 1610,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:10"
         },
@@ -796,7 +834,7 @@
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "______gap",
-          "astId": 1704,
+          "astId": 1710,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:10"
         },
@@ -804,7 +842,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "_paused",
-          "astId": 5582,
+          "astId": 5617,
           "type": "t_bool",
           "src": "909:20:44"
         },
@@ -812,7 +850,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "______gap",
-          "astId": 5665,
+          "astId": 5700,
           "type": "t_array:50<t_uint256>",
           "src": "2163:29:44"
         },
@@ -820,9 +858,9 @@
           "contract": "ERC721Pausable",
           "path": "contracts/token/ERC721/ERC721Pausable.sol",
           "label": "______gap",
-          "astId": 13519,
+          "astId": 13871,
           "type": "t_array:50<t_uint256>",
-          "src": "869:29:146"
+          "src": "869:29:149"
         }
       ],
       "warnings": {
@@ -845,7 +883,7 @@
     "address": "0xa44bb80b290dE8a465d17B14269dF53CF0B9Bf4f"
   },
   "provider": {
-    "address": "0xD2965FcE42d06257EeD1B6907694ceD467F9240F"
+    "address": "0x874BD0F6ae1f65016f12E5c314AF18782B2D3866"
   },
-  "version": "2.4.0"
+  "version": "2.5.0"
 }

--- a/.openzeppelin/ropsten.json
+++ b/.openzeppelin/ropsten.json
@@ -1,389 +1,11 @@
 {
   "contracts": {
-    "StandaloneERC20": {
-      "address": "0x92B3388fF9f2021aF0Ae3c18CEfcEbB869DA8Fac",
-      "constructorCode": "60806040525b5b61000b565b61372e8061001a6000396000f3fe",
-      "bodyBytecodeHash": "e85eba9d1581c280b848dcd3b157b8b519012a715adc705ed19e0e3b2d1331fe",
-      "localBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "deployedBytecodeHash": "b890f33a22c45c2844f4de44eff9cc344d9249ecc90dfd23e8d852b2e2fe0eeb",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_string": {
-          "id": "t_string",
-          "kind": "elementary",
-          "label": "string"
-        },
-        "t_uint8": {
-          "id": "t_uint8",
-          "kind": "elementary",
-          "label": "uint8"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        },
-        "t_struct<Roles.Role>": {
-          "id": "t_struct<Roles.Role>",
-          "kind": "struct",
-          "label": "Roles.Role",
-          "members": [
-            {
-              "label": "bearer",
-              "astId": 1261,
-              "type": "t_mapping<t_bool>",
-              "src": "150:32:7"
-            }
-          ]
-        },
-        "t_mapping<t_bool>": {
-          "id": "t_mapping<t_bool>",
-          "valueType": "t_bool",
-          "label": "mapping(key => bool)",
-          "kind": "mapping"
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 3,
-          "type": "t_bool",
-          "src": "757:24:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 5,
-          "type": "t_bool",
-          "src": "876:25:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 61,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_name",
-          "astId": 11159,
-          "type": "t_string",
-          "src": "224:20:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_symbol",
-          "astId": 11161,
-          "type": "t_string",
-          "src": "250:22:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "_decimals",
-          "astId": 11163,
-          "type": "t_uint8",
-          "src": "278:23:131"
-        },
-        {
-          "contract": "ERC20Detailed",
-          "path": "contracts/token/ERC20/ERC20Detailed.sol",
-          "label": "______gap",
-          "astId": 11215,
-          "type": "t_array:50<t_uint256>",
-          "src": "1654:29:131"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_balances",
-          "astId": 10639,
-          "type": "t_mapping<t_uint256>",
-          "src": "1418:46:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_allowances",
-          "astId": 10645,
-          "type": "t_mapping<t_uint256>",
-          "src": "1471:69:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "_totalSupply",
-          "astId": 10647,
-          "type": "t_uint256",
-          "src": "1547:28:128"
-        },
-        {
-          "contract": "ERC20",
-          "path": "contracts/token/ERC20/ERC20.sol",
-          "label": "______gap",
-          "astId": 11031,
-          "type": "t_array:50<t_uint256>",
-          "src": "8173:29:128"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "_minters",
-          "astId": 1481,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:9"
-        },
-        {
-          "contract": "MinterRole",
-          "path": "contracts/access/roles/MinterRole.sol",
-          "label": "______gap",
-          "astId": 1581,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:9"
-        },
-        {
-          "contract": "ERC20Mintable",
-          "path": "contracts/token/ERC20/ERC20Mintable.sol",
-          "label": "______gap",
-          "astId": 11264,
-          "type": "t_array:50<t_uint256>",
-          "src": "831:29:132"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "_pausers",
-          "astId": 1604,
-          "type": "t_struct<Roles.Role>",
-          "src": "327:27:10"
-        },
-        {
-          "contract": "PauserRole",
-          "path": "contracts/access/roles/PauserRole.sol",
-          "label": "______gap",
-          "astId": 1704,
-          "type": "t_array:50<t_uint256>",
-          "src": "1193:29:10"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "_paused",
-          "astId": 5582,
-          "type": "t_bool",
-          "src": "909:20:44"
-        },
-        {
-          "contract": "Pausable",
-          "path": "contracts/lifecycle/Pausable.sol",
-          "label": "______gap",
-          "astId": 5665,
-          "type": "t_array:50<t_uint256>",
-          "src": "2163:29:44"
-        },
-        {
-          "contract": "ERC20Pausable",
-          "path": "contracts/token/ERC20/ERC20Pausable.sol",
-          "label": "______gap",
-          "astId": 11387,
-          "type": "t_array:50<t_uint256>",
-          "src": "1371:29:133"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
-      }
-    },
-    "TokenVesting": {
-      "address": "0xceB212CB9BBA9E789788a8AF4C93B8dF6927be9f",
-      "constructorCode": "60806040525b5b61000b565b611f958061001a6000396000f3fe",
-      "bodyBytecodeHash": "bed509f74341ca413ee16f728b8d7ad30668fbbc9c01cc89eae2d42b7dd889b1",
-      "localBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
-      "deployedBytecodeHash": "e85035b45c1eb8d67f8826346fef6173562c2f82dc58ba40e4d72bca6a56405f",
-      "types": {
-        "t_bool": {
-          "id": "t_bool",
-          "kind": "elementary",
-          "label": "bool"
-        },
-        "t_uint256": {
-          "id": "t_uint256",
-          "kind": "elementary",
-          "label": "uint256"
-        },
-        "t_array:50<t_uint256>": {
-          "id": "t_array:50<t_uint256>",
-          "valueType": "t_uint256",
-          "length": "50",
-          "kind": "array",
-          "label": "uint256[50]"
-        },
-        "t_address": {
-          "id": "t_address",
-          "kind": "elementary",
-          "label": "address"
-        },
-        "t_mapping<t_uint256>": {
-          "id": "t_mapping<t_uint256>",
-          "valueType": "t_uint256",
-          "label": "mapping(key => uint256)",
-          "kind": "mapping"
-        },
-        "t_mapping<t_bool>": {
-          "id": "t_mapping<t_bool>",
-          "valueType": "t_bool",
-          "label": "mapping(key => bool)",
-          "kind": "mapping"
-        }
-      },
-      "storage": [
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initialized",
-          "astId": 3,
-          "type": "t_bool",
-          "src": "757:24:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "initializing",
-          "astId": 5,
-          "type": "t_bool",
-          "src": "876:25:0"
-        },
-        {
-          "contract": "Initializable",
-          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
-          "label": "______gap",
-          "astId": 61,
-          "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
-        },
-        {
-          "contract": "Ownable",
-          "path": "contracts/ownership/Ownable.sol",
-          "label": "_owner",
-          "astId": 9652,
-          "type": "t_address",
-          "src": "526:22:121"
-        },
-        {
-          "contract": "Ownable",
-          "path": "contracts/ownership/Ownable.sol",
-          "label": "______gap",
-          "astId": 9765,
-          "type": "t_array:50<t_uint256>",
-          "src": "2471:29:121"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_beneficiary",
-          "astId": 4676,
-          "type": "t_address",
-          "src": "1148:28:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_cliff",
-          "astId": 4678,
-          "type": "t_uint256",
-          "src": "1278:22:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_start",
-          "astId": 4680,
-          "type": "t_uint256",
-          "src": "1306:22:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_duration",
-          "astId": 4682,
-          "type": "t_uint256",
-          "src": "1334:25:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_revocable",
-          "astId": 4684,
-          "type": "t_bool",
-          "src": "1366:23:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_released",
-          "astId": 4688,
-          "type": "t_mapping<t_uint256>",
-          "src": "1396:46:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "_revoked",
-          "astId": 4692,
-          "type": "t_mapping<t_bool>",
-          "src": "1448:42:35"
-        },
-        {
-          "contract": "TokenVesting",
-          "path": "contracts/drafts/TokenVesting.sol",
-          "label": "______gap",
-          "astId": 5041,
-          "type": "t_array:50<t_uint256>",
-          "src": "6241:29:35"
-        }
-      ],
-      "warnings": {
-        "hasConstructor": false,
-        "hasSelfDestruct": false,
-        "hasDelegateCall": false,
-        "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
-      }
-    },
     "StandaloneERC721": {
-      "address": "0x57EEbbB21BDe827c22c0AFF044969AfF043BB05C",
-      "constructorCode": "60806040525b5b61000b565b614a688061001a6000396000f3fe",
-      "bodyBytecodeHash": "4c4911b0db948d783dd8e71b2bc11b81c442c8959103e31484b62e71770008da",
-      "localBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
-      "deployedBytecodeHash": "eacf0c4c879c1a73d9692b4332f807e3ddb4cccf89bf1ea01fee7744898a56e9",
+      "address": "0xf7aB09a83753b8cfa9E33DC95BB9f02E49b139e3",
+      "constructorCode": "6080604052614852806100136000396000f3fe",
+      "bodyBytecodeHash": "88b94d215b26608378556f9b1eaa4c698e55d1f925c92ab2a1896edc517a4ace",
+      "localBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
+      "deployedBytecodeHash": "d2ff23778047a3016e041423d2417366c2b4205da01d6f19b6691ed4cb9bf690",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -426,7 +48,7 @@
           "members": [
             {
               "label": "_value",
-              "astId": 3804,
+              "astId": 3810,
               "type": "t_uint256",
               "src": "1024:14:29"
             }
@@ -468,6 +90,13 @@
           "label": "mapping(key => string)",
           "kind": "mapping"
         },
+        "t_array:49<t_uint256>": {
+          "id": "t_array:49<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "49",
+          "kind": "array",
+          "label": "uint256[49]"
+        },
         "t_struct<Roles.Role>": {
           "id": "t_struct<Roles.Role>",
           "kind": "struct",
@@ -475,7 +104,7 @@
           "members": [
             {
               "label": "bearer",
-              "astId": 1261,
+              "astId": 1267,
               "type": "t_mapping<t_bool>",
               "src": "150:32:7"
             }
@@ -503,15 +132,15 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "ERC165",
           "path": "contracts/introspection/ERC165.sol",
           "label": "_supportedInterfaces",
-          "astId": 5215,
+          "astId": 5221,
           "type": "t_mapping<t_bool>",
           "src": "565:52:38"
         },
@@ -519,7 +148,7 @@
           "contract": "ERC165",
           "path": "contracts/introspection/ERC165.sol",
           "label": "______gap",
-          "astId": 5260,
+          "astId": 5266,
           "type": "t_array:50<t_uint256>",
           "src": "1729:29:38"
         },
@@ -527,119 +156,127 @@
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_tokenOwner",
-          "astId": 12030,
+          "astId": 12307,
           "type": "t_mapping<t_address>",
-          "src": "886:48:138"
+          "src": "886:48:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_tokenApprovals",
-          "astId": 12034,
+          "astId": 12311,
           "type": "t_mapping<t_address>",
-          "src": "990:52:138"
+          "src": "990:52:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_ownedTokensCount",
-          "astId": 12038,
+          "astId": 12315,
           "type": "t_mapping<t_struct<Counters.Counter>>",
-          "src": "1100:63:138"
+          "src": "1100:63:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "_operatorApprovals",
-          "astId": 12044,
+          "astId": 12321,
           "type": "t_mapping<t_bool>",
-          "src": "1218:73:138"
+          "src": "1218:73:141"
         },
         {
           "contract": "ERC721",
           "path": "contracts/token/ERC721/ERC721.sol",
           "label": "______gap",
-          "astId": 12656,
+          "astId": 12967,
           "type": "t_array:50<t_uint256>",
-          "src": "15262:29:138"
+          "src": "16014:29:141"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_ownedTokens",
-          "astId": 12714,
+          "astId": 13025,
           "type": "t_mapping<t_array:dyn<t_uint256>>",
-          "src": "502:50:140"
+          "src": "502:50:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_ownedTokensIndex",
-          "astId": 12718,
+          "astId": 13029,
           "type": "t_mapping<t_uint256>",
-          "src": "622:53:140"
+          "src": "622:53:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_allTokens",
-          "astId": 12721,
+          "astId": 13032,
           "type": "t_array:dyn<t_uint256>",
-          "src": "736:28:140"
+          "src": "736:28:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "_allTokensIndex",
-          "astId": 12725,
+          "astId": 13036,
           "type": "t_mapping<t_uint256>",
-          "src": "835:51:140"
+          "src": "835:51:143"
         },
         {
           "contract": "ERC721Enumerable",
           "path": "contracts/token/ERC721/ERC721Enumerable.sol",
           "label": "______gap",
-          "astId": 13056,
+          "astId": 13367,
           "type": "t_array:50<t_uint256>",
-          "src": "9053:29:140"
+          "src": "9053:29:143"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_name",
-          "astId": 13126,
+          "astId": 13437,
           "type": "t_string",
-          "src": "323:20:143"
+          "src": "323:20:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_symbol",
-          "astId": 13128,
+          "astId": 13439,
           "type": "t_string",
-          "src": "370:22:143"
+          "src": "370:22:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "_tokenURIs",
-          "astId": 13132,
+          "astId": 13443,
           "type": "t_mapping<t_string>",
-          "src": "438:45:143"
+          "src": "438:45:146"
+        },
+        {
+          "contract": "ERC721Metadata",
+          "path": "contracts/token/ERC721/ERC721Metadata.sol",
+          "label": "_baseURI",
+          "astId": 13445,
+          "type": "t_string",
+          "src": "506:23:146"
         },
         {
           "contract": "ERC721Metadata",
           "path": "contracts/token/ERC721/ERC721Metadata.sol",
           "label": "______gap",
-          "astId": 13263,
-          "type": "t_array:50<t_uint256>",
-          "src": "3086:29:143"
+          "astId": 13615,
+          "type": "t_array:49<t_uint256>",
+          "src": "4297:29:146"
         },
         {
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "_minters",
-          "astId": 1481,
+          "astId": 1487,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:9"
         },
@@ -647,7 +284,7 @@
           "contract": "MinterRole",
           "path": "contracts/access/roles/MinterRole.sol",
           "label": "______gap",
-          "astId": 1581,
+          "astId": 1587,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:9"
         },
@@ -655,15 +292,15 @@
           "contract": "ERC721MetadataMintable",
           "path": "contracts/token/ERC721/ERC721MetadataMintable.sol",
           "label": "______gap",
-          "astId": 13333,
+          "astId": 13685,
           "type": "t_array:50<t_uint256>",
-          "src": "1057:29:144"
+          "src": "1057:29:147"
         },
         {
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "_pausers",
-          "astId": 1604,
+          "astId": 1610,
           "type": "t_struct<Roles.Role>",
           "src": "327:27:10"
         },
@@ -671,7 +308,7 @@
           "contract": "PauserRole",
           "path": "contracts/access/roles/PauserRole.sol",
           "label": "______gap",
-          "astId": 1704,
+          "astId": 1710,
           "type": "t_array:50<t_uint256>",
           "src": "1193:29:10"
         },
@@ -679,7 +316,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "_paused",
-          "astId": 5582,
+          "astId": 5617,
           "type": "t_bool",
           "src": "909:20:44"
         },
@@ -687,7 +324,7 @@
           "contract": "Pausable",
           "path": "contracts/lifecycle/Pausable.sol",
           "label": "______gap",
-          "astId": 5665,
+          "astId": 5700,
           "type": "t_array:50<t_uint256>",
           "src": "2163:29:44"
         },
@@ -695,9 +332,9 @@
           "contract": "ERC721Pausable",
           "path": "contracts/token/ERC721/ERC721Pausable.sol",
           "label": "______gap",
-          "astId": 13519,
+          "astId": 13871,
           "type": "t_array:50<t_uint256>",
-          "src": "869:29:146"
+          "src": "869:29:149"
         }
       ],
       "warnings": {
@@ -705,15 +342,475 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "ERC721",
+            "path": "contracts/token/ERC721/ERC721.sol",
+            "label": "_ownedTokensCount",
+            "astId": 12315,
+            "type": "t_mapping<t_struct<Counters.Counter>>",
+            "src": "1100:63:141"
+          },
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": [
+          {
+            "action": "replace",
+            "updated": {
+              "index": 18,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "_baseURI",
+              "astId": 13445,
+              "type": "t_string",
+              "src": "506:23:146"
+            },
+            "original": {
+              "index": 18,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "______gap",
+              "astId": 13263,
+              "type": "t_array:50<t_uint256>",
+              "src": "3086:29:143"
+            }
+          },
+          {
+            "action": "insert",
+            "updated": {
+              "index": 19,
+              "contract": "ERC721Metadata",
+              "path": "contracts/token/ERC721/ERC721Metadata.sol",
+              "label": "______gap",
+              "astId": 13615,
+              "type": "t_array:49<t_uint256>",
+              "src": "4297:29:146"
+            }
+          }
+        ]
+      }
+    },
+    "StandaloneERC20": {
+      "address": "0x2C12d9bEf08767ecE0Ef2c0D7aaFB034826462D1",
+      "constructorCode": "6080604052613351806100136000396000f3fe",
+      "bodyBytecodeHash": "5fece1bdf65e93391feb0bdf0c967cf306feb4e9cba3e43431d5974146bf0093",
+      "localBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "deployedBytecodeHash": "3c51effc0b3d25e6a30b6e16ce9a93a6705be6927185f8b0af083a6a3cc3e905",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_string": {
+          "id": "t_string",
+          "kind": "elementary",
+          "label": "string"
+        },
+        "t_uint8": {
+          "id": "t_uint8",
+          "kind": "elementary",
+          "label": "uint8"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_struct<Roles.Role>": {
+          "id": "t_struct<Roles.Role>",
+          "kind": "struct",
+          "label": "Roles.Role",
+          "members": [
+            {
+              "label": "bearer",
+              "astId": 1267,
+              "type": "t_mapping<t_bool>",
+              "src": "150:32:7"
+            }
+          ]
+        },
+        "t_mapping<t_bool>": {
+          "id": "t_mapping<t_bool>",
+          "valueType": "t_bool",
+          "label": "mapping(key => bool)",
+          "kind": "mapping"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 3,
+          "type": "t_bool",
+          "src": "757:24:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5,
+          "type": "t_bool",
+          "src": "876:25:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 67,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:0"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_name",
+          "astId": 11436,
+          "type": "t_string",
+          "src": "224:20:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_symbol",
+          "astId": 11438,
+          "type": "t_string",
+          "src": "250:22:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "_decimals",
+          "astId": 11440,
+          "type": "t_uint8",
+          "src": "278:23:134"
+        },
+        {
+          "contract": "ERC20Detailed",
+          "path": "contracts/token/ERC20/ERC20Detailed.sol",
+          "label": "______gap",
+          "astId": 11492,
+          "type": "t_array:50<t_uint256>",
+          "src": "1654:29:134"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_balances",
+          "astId": 10916,
+          "type": "t_mapping<t_uint256>",
+          "src": "1418:46:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_allowances",
+          "astId": 10922,
+          "type": "t_mapping<t_uint256>",
+          "src": "1471:69:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "_totalSupply",
+          "astId": 10924,
+          "type": "t_uint256",
+          "src": "1547:28:131"
+        },
+        {
+          "contract": "ERC20",
+          "path": "contracts/token/ERC20/ERC20.sol",
+          "label": "______gap",
+          "astId": 11308,
+          "type": "t_array:50<t_uint256>",
+          "src": "8172:29:131"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "_minters",
+          "astId": 1487,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:9"
+        },
+        {
+          "contract": "MinterRole",
+          "path": "contracts/access/roles/MinterRole.sol",
+          "label": "______gap",
+          "astId": 1587,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:9"
+        },
+        {
+          "contract": "ERC20Mintable",
+          "path": "contracts/token/ERC20/ERC20Mintable.sol",
+          "label": "______gap",
+          "astId": 11541,
+          "type": "t_array:50<t_uint256>",
+          "src": "831:29:135"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "_pausers",
+          "astId": 1610,
+          "type": "t_struct<Roles.Role>",
+          "src": "327:27:10"
+        },
+        {
+          "contract": "PauserRole",
+          "path": "contracts/access/roles/PauserRole.sol",
+          "label": "______gap",
+          "astId": 1710,
+          "type": "t_array:50<t_uint256>",
+          "src": "1193:29:10"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "_paused",
+          "astId": 5617,
+          "type": "t_bool",
+          "src": "909:20:44"
+        },
+        {
+          "contract": "Pausable",
+          "path": "contracts/lifecycle/Pausable.sol",
+          "label": "______gap",
+          "astId": 5700,
+          "type": "t_array:50<t_uint256>",
+          "src": "2163:29:44"
+        },
+        {
+          "contract": "ERC20Pausable",
+          "path": "contracts/token/ERC20/ERC20Pausable.sol",
+          "label": "______gap",
+          "astId": 11664,
+          "type": "t_array:50<t_uint256>",
+          "src": "1371:29:136"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [
+          {
+            "contract": "MinterRole",
+            "path": "contracts/access/roles/MinterRole.sol",
+            "label": "_minters",
+            "astId": 1487,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:9"
+          },
+          {
+            "contract": "PauserRole",
+            "path": "contracts/access/roles/PauserRole.sol",
+            "label": "_pausers",
+            "astId": 1610,
+            "type": "t_struct<Roles.Role>",
+            "src": "327:27:10"
+          }
+        ],
+        "storageDiff": []
+      }
+    },
+    "TokenVesting": {
+      "address": "0x767959F7F6852f32CDe1D28483698F62Fa38317b",
+      "constructorCode": "6080604052611de2806100136000396000f3fe",
+      "bodyBytecodeHash": "53b6c1230e5389805143264fff3365c615b5f0af3bb66a345f0c1537407097c4",
+      "localBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
+      "deployedBytecodeHash": "375eceb6a96eaef3ac4f275ddd18e1caceab47d4729444085f99b6d9520eb451",
+      "types": {
+        "t_bool": {
+          "id": "t_bool",
+          "kind": "elementary",
+          "label": "bool"
+        },
+        "t_uint256": {
+          "id": "t_uint256",
+          "kind": "elementary",
+          "label": "uint256"
+        },
+        "t_array:50<t_uint256>": {
+          "id": "t_array:50<t_uint256>",
+          "valueType": "t_uint256",
+          "length": "50",
+          "kind": "array",
+          "label": "uint256[50]"
+        },
+        "t_address": {
+          "id": "t_address",
+          "kind": "elementary",
+          "label": "address"
+        },
+        "t_mapping<t_uint256>": {
+          "id": "t_mapping<t_uint256>",
+          "valueType": "t_uint256",
+          "label": "mapping(key => uint256)",
+          "kind": "mapping"
+        },
+        "t_mapping<t_bool>": {
+          "id": "t_mapping<t_bool>",
+          "valueType": "t_bool",
+          "label": "mapping(key => bool)",
+          "kind": "mapping"
+        }
+      },
+      "storage": [
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initialized",
+          "astId": 3,
+          "type": "t_bool",
+          "src": "757:24:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "initializing",
+          "astId": 5,
+          "type": "t_bool",
+          "src": "876:25:0"
+        },
+        {
+          "contract": "Initializable",
+          "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
+          "label": "______gap",
+          "astId": 67,
+          "type": "t_array:50<t_uint256>",
+          "src": "1982:29:0"
+        },
+        {
+          "contract": "Ownable",
+          "path": "contracts/ownership/Ownable.sol",
+          "label": "_owner",
+          "astId": 9929,
+          "type": "t_address",
+          "src": "526:22:124"
+        },
+        {
+          "contract": "Ownable",
+          "path": "contracts/ownership/Ownable.sol",
+          "label": "______gap",
+          "astId": 10042,
+          "type": "t_array:50<t_uint256>",
+          "src": "2471:29:124"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_beneficiary",
+          "astId": 4682,
+          "type": "t_address",
+          "src": "1148:28:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_cliff",
+          "astId": 4684,
+          "type": "t_uint256",
+          "src": "1278:22:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_start",
+          "astId": 4686,
+          "type": "t_uint256",
+          "src": "1306:22:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_duration",
+          "astId": 4688,
+          "type": "t_uint256",
+          "src": "1334:25:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_revocable",
+          "astId": 4690,
+          "type": "t_bool",
+          "src": "1366:23:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_released",
+          "astId": 4694,
+          "type": "t_mapping<t_uint256>",
+          "src": "1396:46:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "_revoked",
+          "astId": 4698,
+          "type": "t_mapping<t_bool>",
+          "src": "1448:42:35"
+        },
+        {
+          "contract": "TokenVesting",
+          "path": "contracts/drafts/TokenVesting.sol",
+          "label": "______gap",
+          "astId": 5047,
+          "type": "t_array:50<t_uint256>",
+          "src": "6241:29:35"
+        }
+      ],
+      "warnings": {
+        "hasConstructor": false,
+        "hasSelfDestruct": false,
+        "hasDelegateCall": false,
+        "hasInitialValuesInDeclarations": false,
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [],
+        "storageDiff": []
       }
     },
     "PaymentSplitter": {
-      "address": "0xC4280Bf761AAce8ABcc9e0e4bf1F3Bd8d1bDbd89",
-      "constructorCode": "60806040525b5b61000b565b6112f18061001a6000396000f3fe",
-      "bodyBytecodeHash": "35557e8a7b14e305cbe138016823233ea344a4366601f5dc7d81c92847e395dd",
-      "localBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
-      "deployedBytecodeHash": "e24988d860877b42d9dd9bca60f90dd8f0cfc019a46019a3dcead150d6d79613",
+      "address": "0x998922b3796f5dCc87C71a5344626105b246eD91",
+      "constructorCode": "60806040526111d3806100136000396000f3fe",
+      "bodyBytecodeHash": "35fd934084a8702affa3466e8127098f9cdad9ae7aa9e2d49263951636d03111",
+      "localBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
+      "deployedBytecodeHash": "536cbeb9a18239c63f290e19987649b2fdf97ed17832cdde1dead9275d877409",
       "types": {
         "t_bool": {
           "id": "t_bool",
@@ -772,57 +869,57 @@
           "contract": "Initializable",
           "path": "@openzeppelin/upgrades/contracts/Initializable.sol",
           "label": "______gap",
-          "astId": 61,
+          "astId": 67,
           "type": "t_array:50<t_uint256>",
-          "src": "1951:29:0"
+          "src": "1982:29:0"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalShares",
-          "astId": 9878,
+          "astId": 10155,
           "type": "t_uint256",
-          "src": "1229:28:123"
+          "src": "1229:28:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_totalReleased",
-          "astId": 9880,
+          "astId": 10157,
           "type": "t_uint256",
-          "src": "1263:30:123"
+          "src": "1263:30:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_shares",
-          "astId": 9884,
+          "astId": 10161,
           "type": "t_mapping<t_uint256>",
-          "src": "1300:43:123"
+          "src": "1300:43:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_released",
-          "astId": 9888,
+          "astId": 10165,
           "type": "t_mapping<t_uint256>",
-          "src": "1349:45:123"
+          "src": "1349:45:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "_payees",
-          "astId": 9891,
+          "astId": 10168,
           "type": "t_array:dyn<t_address>",
-          "src": "1400:25:123"
+          "src": "1400:25:126"
         },
         {
           "contract": "PaymentSplitter",
           "path": "contracts/payment/PaymentSplitter.sol",
           "label": "______gap",
-          "astId": 10144,
+          "astId": 10421,
           "type": "t_array:50<t_uint256>",
-          "src": "5190:29:123"
+          "src": "5190:29:126"
         }
       ],
       "warnings": {
@@ -830,7 +927,9 @@
         "hasSelfDestruct": false,
         "hasDelegateCall": false,
         "hasInitialValuesInDeclarations": false,
-        "uninitializedBaseContracts": []
+        "uninitializedBaseContracts": [],
+        "storageUncheckedVars": [],
+        "storageDiff": []
       }
     }
   },
@@ -845,7 +944,7 @@
     "address": "0x2a9e7B63514438906A83a1e320dBBD814D417002"
   },
   "provider": {
-    "address": "0x9EC05298B9e7f49a969734460009FFd03420B8e3"
+    "address": "0x6936a1b1DB054E5C38a82a4B7c6500B7b841F46b"
   },
-  "version": "2.4.0"
+  "version": "2.5.0"
 }


### PR DESCRIPTION
These are the updated project files, following the deployment of the v2.5 contracts.

To get this, I run the following commands for all 4 networks:
 - `npx oz bump 2.5.0`
 - `npx oz push -n <network> --force`
 - `npx oz freeze -n <network>`

The `--force` was required due to a new storage variable being introduced in `ERC721Detailed`: see https://github.com/OpenZeppelin/openzeppelin-contracts-ethereum-package/pull/76 for more details.