### PR TITLE
Allow _msgSender override by OpenGSN

### DIFF
--- a/contracts/GSN/Context.sol
+++ b/contracts/GSN/Context.sol
@@ -18,7 +18,7 @@ contract Context is Initializable {
     constructor () internal { }
     // solhint-disable-previous-line no-empty-blocks
 
-    function _msgSender() internal view returns (address payable) {
+    function _msgSender() internal view returns (address) {
         return msg.sender;
     }
 

--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -97,7 +97,7 @@ contract GSNRecipient is Initializable, IRelayRecipient, Context {
      *
      * IMPORTANT: Contracts derived from {GSNRecipient} should never use `msg.sender`, and use {_msgSender} instead.
      */
-    function _msgSender() internal view returns (address payable) {
+    function _msgSender() internal view returns (address) {
         if (msg.sender != _relayHub) {
             return msg.sender;
         } else {


### PR DESCRIPTION
I am using OpenGSN with an openzeppelin ERC20 contract.
When using @opengsn/gsn/contracts/BaseRelayRecipient.sol, I got a compilation error : 
```
Compilation errors:
@openzeppelin/contracts-ethereum-package/contracts/GSN/Context.sol:21:5: TypeError: Overriding function return types differ.
    function _msgSender() internal view returns (address payable) {
    ^ (Relevant source part starts here and spans across multiple lines).
@opengsn/gsn/contracts/BaseRelayRecipient.sol:35:5: Overridden function is here:
    function _msgSender() internal view returns (address) {
    ^ (Relevant source part starts here and spans across multiple lines).
```

I propose this fix to allow override by https://github.com/opengsn/gsn/blob/master/contracts/BaseRelayRecipient.sol#L35
