### PR TITLE
Added "virtual" modifier to allow for overrides

### DIFF
--- a/contracts/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/presets/ERC20PresetMinterPauser.sol
@@ -66,7 +66,7 @@ contract ERC20PresetMinterPauserUpgradeSafe is Initializable, ContextUpgradeSafe
      *
      * - the caller must have the `MINTER_ROLE`.
      */
-    function mint(address to, uint256 amount) public {
+    function mint(address to, uint256 amount) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC20PresetMinterPauser: must have minter role to mint");
         _mint(to, amount);
     }

--- a/contracts/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/presets/ERC721PresetMinterPauserAutoId.sol
@@ -78,7 +78,7 @@ contract ERC721PresetMinterPauserAutoIdUpgradeSafe is Initializable, ContextUpgr
      *
      * - the caller must have the `MINTER_ROLE`.
      */
-    function mint(address to) public {
+    function mint(address to) public virtual {
         require(hasRole(MINTER_ROLE, _msgSender()), "ERC721PresetMinterPauserAutoId: must have minter role to mint");
 
         // We can just use balanceOf to create the new tokenId because tokens


### PR DESCRIPTION
1. Discussion (one-sided at the time of this request) of this PR can be found here: https://forum.openzeppelin.com/t/erc721presetminterpauserautoid-mint-function-and-tokenid/2780/8

2. The preset `mint` function is not override-able by parent contracts as it is not marked as `virtual`. Since `mint` is not part of the ERC721 standard, and the ability to user `super` and OZ's outstanding presets exists, why not allow for more flexibility?
