### PR TITLE
add SPDX license identifiers

### DIFF
--- a/contracts/GSN/Context.sol
+++ b/contracts/GSN/Context.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 import "../Initializable.sol";
 

--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IRelayRecipient.sol";

--- a/contracts/GSN/GSNRecipientERC20Fee.sol
+++ b/contracts/GSN/GSNRecipientERC20Fee.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./GSNRecipient.sol";

--- a/contracts/GSN/GSNRecipientSignature.sol
+++ b/contracts/GSN/GSNRecipientSignature.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./GSNRecipient.sol";

--- a/contracts/GSN/IRelayHub.sol
+++ b/contracts/GSN/IRelayHub.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/GSN/IRelayRecipient.sol
+++ b/contracts/GSN/IRelayRecipient.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/Initializable.sol
+++ b/contracts/Initializable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity >=0.4.24 <0.7.0;
 
 

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/EnumerableSet.sol";

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/SafeERC20.sol";

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC165.sol";

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 /**

--- a/contracts/introspection/ERC1820Implementer.sol
+++ b/contracts/introspection/ERC1820Implementer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC1820Implementer.sol";

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/introspection/IERC1820Implementer.sol
+++ b/contracts/introspection/IERC1820Implementer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/introspection/IERC1820Registry.sol
+++ b/contracts/introspection/IERC1820Registry.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC721Receiver.sol";

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./ERC721.sol";

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "../../introspection/IERC165.sol";

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "./IERC721.sol";

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "./IERC721.sol";

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 /**

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/Math.sol";

--- a/contracts/utils/Counters.sol
+++ b/contracts/utils/Counters.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/SafeMath.sol";

--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/Pausable.sol
+++ b/contracts/utils/Pausable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 import "../Initializable.sol";
 

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->

<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

This adds SPDX license identifiers to the top of each contract, silencing warnings from the solc compiler. 

These identifiers are already in the [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) repository, e.g:
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L1

<!-- 3. Before submitting, please make sure that you have:
  - reviewed the OpenZeppelin Contributor Guidelines
    (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CONTRIBUTING.md),
  - added tests where applicable to test new functionality,
  - made sure that your contracts are well-documented,
  - run the Solidity linter (`npm run lint:sol`) and fixed any issues,
  - run the JS linter and fixed any issues (`npm run lint:fix`), and
  - updated the changelog, if applicable.
-->
