### PR TITLE
add SPDX license identifiers

### DIFF
--- a/contracts/GSN/Context.sol
+++ b/contracts/GSN/Context.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 import "../Initializable.sol";
 

--- a/contracts/GSN/GSNRecipient.sol
+++ b/contracts/GSN/GSNRecipient.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IRelayRecipient.sol";

--- a/contracts/GSN/GSNRecipientERC20Fee.sol
+++ b/contracts/GSN/GSNRecipientERC20Fee.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./GSNRecipient.sol";

--- a/contracts/GSN/GSNRecipientSignature.sol
+++ b/contracts/GSN/GSNRecipientSignature.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./GSNRecipient.sol";

--- a/contracts/GSN/IRelayHub.sol
+++ b/contracts/GSN/IRelayHub.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/GSN/IRelayRecipient.sol
+++ b/contracts/GSN/IRelayRecipient.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/Initializable.sol
+++ b/contracts/Initializable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity >=0.4.24 <0.7.0;
 
 

--- a/contracts/access/AccessControl.sol
+++ b/contracts/access/AccessControl.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/EnumerableSet.sol";

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/drafts/TokenVesting.sol
+++ b/contracts/drafts/TokenVesting.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/SafeERC20.sol";

--- a/contracts/introspection/ERC165.sol
+++ b/contracts/introspection/ERC165.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC165.sol";

--- a/contracts/introspection/ERC165Checker.sol
+++ b/contracts/introspection/ERC165Checker.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 /**

--- a/contracts/introspection/ERC1820Implementer.sol
+++ b/contracts/introspection/ERC1820Implementer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC1820Implementer.sol";

--- a/contracts/introspection/IERC165.sol
+++ b/contracts/introspection/IERC165.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/introspection/IERC1820Implementer.sol
+++ b/contracts/introspection/IERC1820Implementer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/introspection/IERC1820Registry.sol
+++ b/contracts/introspection/IERC1820Registry.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/math/Math.sol
+++ b/contracts/math/Math.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/math/SignedSafeMath.sol
+++ b/contracts/math/SignedSafeMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/mocks/AccessControlMock.sol
+++ b/contracts/mocks/AccessControlMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../access/AccessControl.sol";

--- a/contracts/mocks/AddressImpl.sol
+++ b/contracts/mocks/AddressImpl.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/Address.sol";

--- a/contracts/mocks/ArraysImpl.sol
+++ b/contracts/mocks/ArraysImpl.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/Arrays.sol";

--- a/contracts/mocks/ConditionalEscrowMock.sol
+++ b/contracts/mocks/ConditionalEscrowMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../payment/escrow/ConditionalEscrow.sol";

--- a/contracts/mocks/ContextMock.sol
+++ b/contracts/mocks/ContextMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/mocks/CountersImpl.sol
+++ b/contracts/mocks/CountersImpl.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/Counters.sol";

--- a/contracts/mocks/Create2Impl.sol
+++ b/contracts/mocks/Create2Impl.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/Create2.sol";

--- a/contracts/mocks/ECDSAMock.sol
+++ b/contracts/mocks/ECDSAMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../cryptography/ECDSA.sol";

--- a/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
+++ b/contracts/mocks/ERC165/ERC165InterfacesSupported.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../introspection/IERC165.sol";

--- a/contracts/mocks/ERC165/ERC165NotSupported.sol
+++ b/contracts/mocks/ERC165/ERC165NotSupported.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 import "../../Initializable.sol";
 

--- a/contracts/mocks/ERC165CheckerMock.sol
+++ b/contracts/mocks/ERC165CheckerMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../introspection/ERC165Checker.sol";

--- a/contracts/mocks/ERC165Mock.sol
+++ b/contracts/mocks/ERC165Mock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../introspection/ERC165.sol";

--- a/contracts/mocks/ERC1820ImplementerMock.sol
+++ b/contracts/mocks/ERC1820ImplementerMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../introspection/ERC1820Implementer.sol";

--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/ERC20Burnable.sol";

--- a/contracts/mocks/ERC20CappedMock.sol
+++ b/contracts/mocks/ERC20CappedMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/ERC20Capped.sol";

--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/ERC20.sol";

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/ERC20.sol";

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/ERC20Pausable.sol";

--- a/contracts/mocks/ERC20PresetMinterPauserMock.sol
+++ b/contracts/mocks/ERC20PresetMinterPauserMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import '../presets/ERC20PresetMinterPauser.sol';

--- a/contracts/mocks/ERC20SnapshotMock.sol
+++ b/contracts/mocks/ERC20SnapshotMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC20/ERC20Snapshot.sol";

--- a/contracts/mocks/ERC721BurnableMock.sol
+++ b/contracts/mocks/ERC721BurnableMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC721/ERC721Burnable.sol";

--- a/contracts/mocks/ERC721GSNRecipientMock.sol
+++ b/contracts/mocks/ERC721GSNRecipientMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC721/ERC721.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC721/ERC721.sol";

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC721/ERC721Pausable.sol";

--- a/contracts/mocks/ERC721PresetMinterPauserAutoIdMock.sol
+++ b/contracts/mocks/ERC721PresetMinterPauserAutoIdMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import '../presets/ERC721PresetMinterPauserAutoId.sol';

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../token/ERC721/IERC721Receiver.sol";

--- a/contracts/mocks/ERC777Mock.sol
+++ b/contracts/mocks/ERC777Mock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/mocks/ERC777SenderRecipientMock.sol
+++ b/contracts/mocks/ERC777SenderRecipientMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/mocks/EnumerableMapMock.sol
+++ b/contracts/mocks/EnumerableMapMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/EnumerableMap.sol";

--- a/contracts/mocks/EnumerableSetMock.sol
+++ b/contracts/mocks/EnumerableSetMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/EnumerableSet.sol";

--- a/contracts/mocks/EscrowMock.sol
+++ b/contracts/mocks/EscrowMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import '../payment/escrow/Escrow.sol';

--- a/contracts/mocks/EtherReceiverMock.sol
+++ b/contracts/mocks/EtherReceiverMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 import "../Initializable.sol";
 

--- a/contracts/mocks/GSNRecipientERC20FeeMock.sol
+++ b/contracts/mocks/GSNRecipientERC20FeeMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/GSNRecipient.sol";

--- a/contracts/mocks/GSNRecipientMock.sol
+++ b/contracts/mocks/GSNRecipientMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./ContextMock.sol";

--- a/contracts/mocks/GSNRecipientSignatureMock.sol
+++ b/contracts/mocks/GSNRecipientSignatureMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/GSNRecipient.sol";

--- a/contracts/mocks/MathMock.sol
+++ b/contracts/mocks/MathMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/Math.sol";

--- a/contracts/mocks/MerkleProofWrapper.sol
+++ b/contracts/mocks/MerkleProofWrapper.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import { MerkleProof } from "../cryptography/MerkleProof.sol";

--- a/contracts/mocks/OwnableMock.sol
+++ b/contracts/mocks/OwnableMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../access/Ownable.sol";

--- a/contracts/mocks/PausableMock.sol
+++ b/contracts/mocks/PausableMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/Pausable.sol";

--- a/contracts/mocks/PaymentSplitterMock.sol
+++ b/contracts/mocks/PaymentSplitterMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import '../payment/PaymentSplitter.sol';

--- a/contracts/mocks/PullPaymentMock.sol
+++ b/contracts/mocks/PullPaymentMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../payment/PullPayment.sol";

--- a/contracts/mocks/ReentrancyAttack.sol
+++ b/contracts/mocks/ReentrancyAttack.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/mocks/ReentrancyMock.sol
+++ b/contracts/mocks/ReentrancyMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/ReentrancyGuard.sol";

--- a/contracts/mocks/RefundEscrowMock.sol
+++ b/contracts/mocks/RefundEscrowMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import '../payment/escrow/RefundEscrow.sol';

--- a/contracts/mocks/SafeCastMock.sol
+++ b/contracts/mocks/SafeCastMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/SafeCast.sol";

--- a/contracts/mocks/SafeERC20Helper.sol
+++ b/contracts/mocks/SafeERC20Helper.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/mocks/SafeMathMock.sol
+++ b/contracts/mocks/SafeMathMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/SafeMath.sol";

--- a/contracts/mocks/SignedSafeMathMock.sol
+++ b/contracts/mocks/SignedSafeMathMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/SignedSafeMath.sol";

--- a/contracts/mocks/StringsMock.sol
+++ b/contracts/mocks/StringsMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../utils/Strings.sol";

--- a/contracts/mocks/TokenTimelockMock.sol
+++ b/contracts/mocks/TokenTimelockMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import '../token/ERC20/TokenTimelock.sol';

--- a/contracts/payment/PaymentSplitter.sol
+++ b/contracts/payment/PaymentSplitter.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/payment/PullPayment.sol
+++ b/contracts/payment/PullPayment.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "./escrow/Escrow.sol";

--- a/contracts/payment/escrow/ConditionalEscrow.sol
+++ b/contracts/payment/escrow/ConditionalEscrow.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./Escrow.sol";

--- a/contracts/payment/escrow/Escrow.sol
+++ b/contracts/payment/escrow/Escrow.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../math/SafeMath.sol";

--- a/contracts/payment/escrow/RefundEscrow.sol
+++ b/contracts/payment/escrow/RefundEscrow.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./ConditionalEscrow.sol";

--- a/contracts/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/presets/ERC20PresetMinterPauser.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../access/AccessControl.sol";

--- a/contracts/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/presets/ERC721PresetMinterPauserAutoId.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../access/AccessControl.sol";

--- a/contracts/token/ERC20/ERC20.sol
+++ b/contracts/token/ERC20/ERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC20/ERC20Burnable.sol
+++ b/contracts/token/ERC20/ERC20Burnable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC20/ERC20Capped.sol
+++ b/contracts/token/ERC20/ERC20Capped.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./ERC20.sol";

--- a/contracts/token/ERC20/ERC20Pausable.sol
+++ b/contracts/token/ERC20/ERC20Pausable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./ERC20.sol";

--- a/contracts/token/ERC20/ERC20Snapshot.sol
+++ b/contracts/token/ERC20/ERC20Snapshot.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../math/SafeMath.sol";

--- a/contracts/token/ERC20/IERC20.sol
+++ b/contracts/token/ERC20/IERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/token/ERC20/SafeERC20.sol
+++ b/contracts/token/ERC20/SafeERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC20.sol";

--- a/contracts/token/ERC20/TokenTimelock.sol
+++ b/contracts/token/ERC20/TokenTimelock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./SafeERC20.sol";

--- a/contracts/token/ERC721/ERC721.sol
+++ b/contracts/token/ERC721/ERC721.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC721/ERC721Burnable.sol
+++ b/contracts/token/ERC721/ERC721Burnable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC721/ERC721Holder.sol
+++ b/contracts/token/ERC721/ERC721Holder.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./IERC721Receiver.sol";

--- a/contracts/token/ERC721/ERC721Pausable.sol
+++ b/contracts/token/ERC721/ERC721Pausable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "./ERC721.sol";

--- a/contracts/token/ERC721/IERC721.sol
+++ b/contracts/token/ERC721/IERC721.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "../../introspection/IERC165.sol";

--- a/contracts/token/ERC721/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/IERC721Enumerable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "./IERC721.sol";

--- a/contracts/token/ERC721/IERC721Metadata.sol
+++ b/contracts/token/ERC721/IERC721Metadata.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 import "./IERC721.sol";

--- a/contracts/token/ERC721/IERC721Receiver.sol
+++ b/contracts/token/ERC721/IERC721Receiver.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../../GSN/Context.sol";

--- a/contracts/token/ERC777/IERC777.sol
+++ b/contracts/token/ERC777/IERC777.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/token/ERC777/IERC777Recipient.sol
+++ b/contracts/token/ERC777/IERC777Recipient.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/token/ERC777/IERC777Sender.sol
+++ b/contracts/token/ERC777/IERC777Sender.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.2;
 
 /**

--- a/contracts/utils/Arrays.sol
+++ b/contracts/utils/Arrays.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/Math.sol";

--- a/contracts/utils/Counters.sol
+++ b/contracts/utils/Counters.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../math/SafeMath.sol";

--- a/contracts/utils/Create2.sol
+++ b/contracts/utils/Create2.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**

--- a/contracts/utils/Pausable.sol
+++ b/contracts/utils/Pausable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 import "../GSN/Context.sol";

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 import "../Initializable.sol";
 

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.0;
 
 /**


### PR DESCRIPTION
This adds SPDX license identifiers to the top of each contract, silencing warnings from the solc compiler. 

These identifiers are already in the [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) repository, e.g:
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L1