### PR TITLE
fix: removes unused parameters and warnings

### DIFF
--- a/contracts/mocks/ERC20BurnableMock.sol
+++ b/contracts/mocks/ERC20BurnableMock.sol
@@ -23,21 +23,17 @@ contract ERC20BurnableMockUpgradeSafe is Initializable, ERC20BurnableUpgradeSafe
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
         __ERC20Burnable_init_unchained();
-        __ERC20BurnableMock_init_unchained(name, symbol, initialAccount, initialBalance);
+        __ERC20BurnableMock_init_unchained(initialAccount, initialBalance);
     }
 
     function __ERC20BurnableMock_init_unchained(
-        string memory name,
-        string memory symbol,
         address initialAccount,
         uint256 initialBalance
     ) internal initializer {
 
-
         _mint(initialAccount, initialBalance);
 
     }
-
 
     uint256[50] private __gap;
 }

--- a/contracts/mocks/ERC20DecimalsMock.sol
+++ b/contracts/mocks/ERC20DecimalsMock.sol
@@ -12,11 +12,10 @@ contract ERC20DecimalsMockUpgradeSafe is Initializable, ERC20UpgradeSafe {
     function __ERC20DecimalsMock_init(string memory name, string memory symbol, uint8 decimals) internal initializer {
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
-        __ERC20DecimalsMock_init_unchained(name, symbol, decimals);
+        __ERC20DecimalsMock_init_unchained(decimals);
     }
 
-    function __ERC20DecimalsMock_init_unchained(string memory name, string memory symbol, uint8 decimals) internal initializer {
-
+    function __ERC20DecimalsMock_init_unchained(uint8 decimals) internal initializer {
 
         _setupDecimals(decimals);
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -23,16 +23,13 @@ contract ERC20MockUpgradeSafe is Initializable, ERC20UpgradeSafe {
     ) internal initializer {
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
-        __ERC20Mock_init_unchained(name, symbol, initialAccount, initialBalance);
+        __ERC20Mock_init_unchained(initialAccount, initialBalance);
     }
 
     function __ERC20Mock_init_unchained(
-        string memory name,
-        string memory symbol,
         address initialAccount,
         uint256 initialBalance
     ) internal initializer {
-
 
         _mint(initialAccount, initialBalance);
 

--- a/contracts/mocks/ERC20PausableMock.sol
+++ b/contracts/mocks/ERC20PausableMock.sol
@@ -25,19 +25,16 @@ contract ERC20PausableMockUpgradeSafe is Initializable, ERC20PausableUpgradeSafe
         __ERC20_init_unchained(name, symbol);
         __Pausable_init_unchained();
         __ERC20Pausable_init_unchained();
-        __ERC20PausableMock_init_unchained(name, symbol, initialAccount, initialBalance);
+        __ERC20PausableMock_init_unchained(initialAccount, initialBalance);
     }
 
     function __ERC20PausableMock_init_unchained(
-        string memory name,
-        string memory symbol,
         address initialAccount,
         uint256 initialBalance
     ) internal initializer {
-
-
+        
         _mint(initialAccount, initialBalance);
-
+   
     }
 
 

--- a/contracts/mocks/ERC20PresetMinterPauserMock.sol
+++ b/contracts/mocks/ERC20PresetMinterPauserMock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import '../presets/ERC20PresetMinterPauser.sol';
+import "../presets/ERC20PresetMinterPauser.sol";
 import "../Initializable.sol";
 
 contract ERC20PresetMinterPauserMockUpgradeSafe is Initializable, ERC20PresetMinterPauserUpgradeSafe {
@@ -16,13 +16,11 @@ contract ERC20PresetMinterPauserMockUpgradeSafe is Initializable, ERC20PresetMin
         __ERC20Burnable_init_unchained();
         __Pausable_init_unchained();
         __ERC20Pausable_init_unchained();
-        __ERC20PresetMinterPauser_init_unchained(name, symbol);
+        __ERC20PresetMinterPauser_init_unchained();
         __ERC20PresetMinterPauserMock_init_unchained(name, symbol);
     }
 
     function __ERC20PresetMinterPauserMock_init_unchained(string memory name, string memory symbol) internal initializer {
-
-
 
     }
 

--- a/contracts/mocks/ERC20SnapshotMock.sol
+++ b/contracts/mocks/ERC20SnapshotMock.sol
@@ -24,19 +24,16 @@ contract ERC20SnapshotMockUpgradeSafe is Initializable, ERC20SnapshotUpgradeSafe
         __Context_init_unchained();
         __ERC20_init_unchained(name, symbol);
         __ERC20Snapshot_init_unchained();
-        __ERC20SnapshotMock_init_unchained(name, symbol, initialAccount, initialBalance);
+        __ERC20SnapshotMock_init_unchained(initialAccount, initialBalance);
     }
 
     function __ERC20SnapshotMock_init_unchained(
-        string memory name,
-        string memory symbol,
         address initialAccount,
         uint256 initialBalance
     ) internal initializer {
-
-
+        
         _mint(initialAccount, initialBalance);
-
+    
     }
 
 

--- a/contracts/mocks/ERC721PausableMock.sol
+++ b/contracts/mocks/ERC721PausableMock.sol
@@ -19,14 +19,12 @@ contract ERC721PausableMockUpgradeSafe is Initializable, ERC721PausableUpgradeSa
         __ERC721_init_unchained(name, symbol);
         __Pausable_init_unchained();
         __ERC721Pausable_init_unchained();
-        __ERC721PausableMock_init_unchained(name, symbol);
+        __ERC721PausableMock_init_unchained();
     }
 
-    function __ERC721PausableMock_init_unchained(string memory name, string memory symbol) internal initializer {
-
-
+    function __ERC721PausableMock_init_unchained() internal initializer {
+    
     }
-
 
     function mint(address to, uint256 tokenId) public {
         super._mint(to, tokenId);

--- a/contracts/mocks/ERC721PresetMinterPauserAutoIdMock.sol
+++ b/contracts/mocks/ERC721PresetMinterPauserAutoIdMock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import '../presets/ERC721PresetMinterPauserAutoId.sol';
+import "../presets/ERC721PresetMinterPauserAutoId.sol";
 import "../Initializable.sol";
 
 contract ERC721PresetMinterPauserAutoIdMockUpgradeSafe is Initializable, ERC721PresetMinterPauserAutoIdUpgradeSafe {
@@ -17,7 +17,7 @@ contract ERC721PresetMinterPauserAutoIdMockUpgradeSafe is Initializable, ERC721P
         __ERC721Burnable_init_unchained();
         __Pausable_init_unchained();
         __ERC721Pausable_init_unchained();
-        __ERC721PresetMinterPauserAutoId_init_unchained(name, symbol, baseURI);
+        __ERC721PresetMinterPauserAutoId_init_unchained(baseURI);
         __ERC721PresetMinterPauserAutoIdMock_init_unchained(name, symbol, baseURI);
     }
 

--- a/contracts/mocks/ERC777Mock.sol
+++ b/contracts/mocks/ERC777Mock.sol
@@ -25,22 +25,17 @@ contract ERC777MockUpgradeSafe is Initializable, ContextUpgradeSafe, ERC777Upgra
     ) internal initializer {
         __Context_init_unchained();
         __ERC777_init_unchained(name, symbol, defaultOperators);
-        __ERC777Mock_init_unchained(initialHolder, initialBalance, name, symbol, defaultOperators);
+        __ERC777Mock_init_unchained(initialHolder, initialBalance);
     }
 
     function __ERC777Mock_init_unchained(
         address initialHolder,
-        uint256 initialBalance,
-        string memory name,
-        string memory symbol,
-        address[] memory defaultOperators
+        uint256 initialBalance
     ) internal initializer {
-
 
         _mint(initialHolder, initialBalance, "", "");
 
     }
-
 
     function mintInternal (
         address to,

--- a/contracts/presets/ERC20PresetMinterPauser.sol
+++ b/contracts/presets/ERC20PresetMinterPauser.sol
@@ -43,10 +43,10 @@ contract ERC20PresetMinterPauserUpgradeSafe is Initializable, ContextUpgradeSafe
         __ERC20Burnable_init_unchained();
         __Pausable_init_unchained();
         __ERC20Pausable_init_unchained();
-        __ERC20PresetMinterPauser_init_unchained(name, symbol);
+        __ERC20PresetMinterPauser_init_unchained();
     }
 
-    function __ERC20PresetMinterPauser_init_unchained(string memory name, string memory symbol) internal initializer {
+    function __ERC20PresetMinterPauser_init_unchained() internal initializer {
 
 
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());

--- a/contracts/presets/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/presets/ERC721PresetMinterPauserAutoId.sol
@@ -51,10 +51,10 @@ contract ERC721PresetMinterPauserAutoIdUpgradeSafe is Initializable, ContextUpgr
         __ERC721Burnable_init_unchained();
         __Pausable_init_unchained();
         __ERC721Pausable_init_unchained();
-        __ERC721PresetMinterPauserAutoId_init_unchained(name, symbol, baseURI);
+        __ERC721PresetMinterPauserAutoId_init_unchained(baseURI);
     }
 
-    function __ERC721PresetMinterPauserAutoId_init_unchained(string memory name, string memory symbol, string memory baseURI) internal initializer {
+    function __ERC721PresetMinterPauserAutoId_init_unchained(string memory baseURI) internal initializer {
 
 
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());


### PR DESCRIPTION
<!-- 0. 🎉 Thank you for submitting a PR! -->

<!-- 1. Does this close any open issues? Please list them below. -->
89
<!-- Keep in mind that new features have a better chance of being merged fast if
they were first discussed and designed with the maintainers. If there is no
corresponding issue, please consider opening one for discussion first! -->

Fixes #89 

<!-- 2. Describe the changes introduced in this pull request. -->
<!--    Include any context necessary for understanding the PR's purpose. -->

* Removes unused parameters and compilation warnings for the following list of Contracts 
`contracts/presets/ERC20PresetMinterPauser.sol`
`contracts/presets/ERC721PresetMinterPauserAutoId.sol`
*WARNING*: Potential breaking change if somebody is already inheriting and using these internal functions.

* Removes unused parameters and compilation warnings for these Mocks:
`contracts/mocks/ERC20BurnableMock.sol`
`contracts/mocks/ERC20DecimalsMock.sol`
`contracts/mocks/ERC20Mock.sol`
`contracts/mocks/ERC20PausableMock.sol`
`contracts/mocks/ERC20PresetMinterPauserMock.sol`
`contracts/mocks/ERC20SnapshotMock.sol`
`contracts/mocks/ERC721PausableMock.sol`
`contracts/mocks/ERC721PresetMinterPauserAutoIdMock.sol`
`contracts/mocks/ERC777Mock.sol`


* Removes some empty blank lines and other minor formatting.

All **Tests** Complete successfully.
